### PR TITLE
Make seach for user email optional

### DIFF
--- a/src/main/java/hudson/tasks/MailAddressResolver.java
+++ b/src/main/java/hudson/tasks/MailAddressResolver.java
@@ -93,18 +93,21 @@ public abstract class MailAddressResolver implements ExtensionPoint {
     public abstract String findMailAddressFor(User u);
     
     public static String resolve(User u) {
-        if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.fine("Resolving e-mail address for \""+u+"\" ID="+u.getId());
-        }
 
-        for (MailAddressResolver r : all()) {
-            String email = r.findMailAddressFor(u);
-            if(email!=null) {
-                if (LOGGER.isLoggable(Level.FINE)) {
-                    LOGGER.fine(r+" resolved "+u.getId()+" to "+email);
+        if (Mailer.descriptor().getTryToResolve()) {
+
+            log("Resolving e-mail address for \""+u+"\" ID="+u.getId());
+
+            for (MailAddressResolver r : all()) {
+                String email = r.findMailAddressFor(u);
+                if(email!=null) {
+                    log(r+" resolved "+u.getId()+" to "+email);
+                    return email;
                 }
-                return email;
             }
+        } else {
+
+            log("Skipping e-mail address resolution for \""+u+"\" ID="+u.getId());
         }
 
         // fall back logic
@@ -127,6 +130,13 @@ public abstract class MailAddressResolver implements ExtensionPoint {
             return u.getId()+ds;
         } else
             return null;
+    }
+
+    private static void log(final String msg) {
+
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.fine(msg);
+        }
     }
 
     /**

--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -225,6 +225,16 @@ public class Mailer extends Notifier {
         private String charset;
         
         /**
+         * If false do not try to resolve e-mail addresses.
+         *
+         * Setting this to false will effectively disable hudson.tasks.MailAddressResolver
+         * extension point.
+         *
+         * @see MailAddressResolver.resolve(User u)
+         */
+        private boolean tryToResolve = true;
+
+        /**
          * Used to keep track of number test e-mails.
          */
         private static transient int testEmailCount = 0;
@@ -333,7 +343,9 @@ public class Mailer extends Notifier {
             charset = json.getString("charset");
             if (charset == null || charset.length() == 0)
             	charset = "UTF-8";
-            
+
+            tryToResolve = json.optBoolean("tryToResolve", true);
+
             save();
             return true;
         }
@@ -380,6 +392,10 @@ public class Mailer extends Notifier {
         	return c;
         }
 
+        public boolean getTryToResolve() {
+            return tryToResolve;
+        }
+
         public void setDefaultSuffix(String defaultSuffix) {
             this.defaultSuffix = defaultSuffix;
         }
@@ -411,6 +427,10 @@ public class Mailer extends Notifier {
         
         public void setCharset(String chaset) {
             this.charset = chaset;
+        }
+
+        public void setTryToResolve(boolean tryToResolve) {
+            this.tryToResolve = tryToResolve;
         }
 
         public void setSmtpAuth(String userName, String password) {

--- a/src/main/resources/hudson/tasks/Mailer/global.jelly
+++ b/src/main/resources/hudson/tasks/Mailer/global.jelly
@@ -61,6 +61,9 @@ THE SOFTWARE.
       <f:entry title="${%Charset}" field="charset">
         <f:textbox />
       </f:entry>
+      <f:entry title="${%Allow user address resolution}" field="tryToResolve">
+        <f:checkbox checked="${h.defaultToTrue(descriptor.tryToResolve)}" />
+      </f:entry>
     </f:advanced>
     <f:optionalBlock title="${%Test configuration by sending test e-mail}">
       <f:entry title="${%Test e-mail recipient}">

--- a/src/main/resources/hudson/tasks/Mailer/help-tryToResolve.html
+++ b/src/main/resources/hudson/tasks/Mailer/help-tryToResolve.html
@@ -1,0 +1,7 @@
+<div>
+Allow e-mail address resolution for users having no address set.
+
+<p>E-mail address resolution is potentially time consuming process. Turning it off
+may speed up certain operations as well as lower the probability of discovering
+user's e-mail address.</p>
+</div>

--- a/src/test/java/hudson/tasks/MailAddressResolverTest.java
+++ b/src/test/java/hudson/tasks/MailAddressResolverTest.java
@@ -1,18 +1,172 @@
 package hudson.tasks;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import hudson.ExtensionList;
+import hudson.model.Hudson;
 import hudson.model.User;
 import hudson.tasks.Mailer.UserProperty;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import jenkins.model.Jenkins;
+
 import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.HudsonTestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 public class MailAddressResolverTest extends HudsonTestCase {
+    
     @Bug(5164)
     public void test5164() {
         Mailer.descriptor().setDefaultSuffix("@example.com");
         String a = User.get("DOMAIN\\user").getProperty(UserProperty.class).getAddress();
         assertEquals("user@example.com",a);
+    }
+
+    /**
+     * @author ogondza
+     */
+    @RunWith(PowerMockRunner.class)
+    @PrepareForTest( {MailAddressResolver.class, Mailer.class, Mailer.DescriptorImpl.class})
+    public static class BehaviouralTest {
+        
+        private User user;
+        private Jenkins jenkins;
+        
+        @Before
+        public void setUp () {
+            
+            jenkins = Mockito.mock(Hudson.class);
+            user = Mockito.mock(User.class);
+            when(user.getFullName()).thenReturn("Full name");
+            when(user.getId()).thenReturn("user_id");
+        }
+    
+    
+
+        @Test
+        public void useAllResolversWhenNothingFound() throws Exception {
+            
+            final MailAddressResolver[] resolvers = {
+                    Mockito.mock(MailAddressResolver.class),
+                    Mockito.mock(MailAddressResolver.class)
+            };
+                            
+            configure(resolvers, true);
+                                   
+            final String address = MailAddressResolver.resolve(user);
+            
+            verify(resolvers[0]).findMailAddressFor(user);
+            verify(resolvers[1]).findMailAddressFor(user);
+            
+            assertNull(address);
+        }
+        
+        @Test
+        public void stopResolutionWhenAddressFound() throws Exception {
+            
+            final MailAddressResolver[] resolvers = {
+                    Mockito.mock(MailAddressResolver.class),
+                    Mockito.mock(MailAddressResolver.class)
+            };
+            
+            when(resolvers[0].findMailAddressFor(user)).thenReturn("mail@addr.com");
+                            
+            configure(resolvers, true);
+                                   
+            final String address = MailAddressResolver.resolve(user);
+            
+            verify(resolvers[0]).findMailAddressFor(user);
+            verify(resolvers[1], never()).findMailAddressFor(user);
+            
+            assertEquals(address, "mail@addr.com");
+        }
+        
+        @Test
+        public void doNetResolveWhenForbidden() throws Exception {
+            
+            final MailAddressResolver[] resolvers = {
+                    Mockito.mock(MailAddressResolver.class)
+            };
+            
+            configure(resolvers, false);
+                                   
+            final String address = MailAddressResolver.resolve(user);
+            
+            verify(resolvers[0], never()).findMailAddressFor(user);
+            
+            assertNull(address);
+        }
+        
+        private void configure(
+                final MailAddressResolver[] resolvers,
+                final boolean resolve
+        ) throws Exception {
+            
+            PowerMockito.spy(Mailer.class);
+            PowerMockito.doReturn(getResolveDescriptor(resolve))
+                    .when(Mailer.class, "descriptor")
+            ;
+            
+            PowerMockito.spy(MailAddressResolver.class);
+            
+            PowerMockito.doReturn(getResolverListMock(jenkins, resolvers))
+                .when(MailAddressResolver.class, "all")
+            ;
+        }
+        
+        private Mailer.DescriptorImpl getResolveDescriptor(final boolean answer) {
+            
+            final Mailer.DescriptorImpl descriptor = PowerMockito.mock(Mailer.DescriptorImpl.class);
+            
+            when(descriptor.getTryToResolve()).thenReturn(answer);
+            
+            return descriptor;
+        }
+        
+        private ExtensionList<MailAddressResolver> getResolverListMock(
+                final Jenkins jenkins,
+                final MailAddressResolver[] resolvers
+        ) {
+            
+            return new MockExtensionList(jenkins, resolvers);
+        }
+        
+        private static class MockExtensionList extends ExtensionList<MailAddressResolver> {
+            
+            private List<MailAddressResolver> extensions;
+            
+            public MockExtensionList(
+                    final Jenkins jenkins,
+                    final MailAddressResolver[] resolvers
+            ) {
+                
+                super(jenkins, MailAddressResolver.class);
+                
+                extensions = Arrays.asList(resolvers);
+            }
+            
+            @Override
+            public Iterator<MailAddressResolver> iterator() {
+                
+                return extensions.iterator();
+            }
+        }
     }
 }


### PR DESCRIPTION
Global Mailer advanced configuration option 'tryToResolve' introduced. It
allows to anable/disable email address resolution globally. Turned on by
default.
