### PR TITLE
[JENKINS-16390] Introduce new resolution method to be used from UI

### DIFF
--- a/src/main/java/hudson/tasks/MailAddressResolver.java
+++ b/src/main/java/hudson/tasks/MailAddressResolver.java
@@ -92,6 +92,10 @@ public abstract class MailAddressResolver implements ExtensionPoint {
      */
     public abstract String findMailAddressFor(User u);
     
+    /**
+     * Try to resolve email address using resolvers.
+     * @return User address or null if resolution failed
+     */
     public static String resolve(User u) {
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.fine("Resolving e-mail address for \""+u+"\" ID="+u.getId());
@@ -108,6 +112,17 @@ public abstract class MailAddressResolver implements ExtensionPoint {
         }
 
         // fall back logic
+        return resolveFast(u);
+    }
+
+    /**
+     * Try to resolve user email address fast enough to be used from UI
+     * <p>
+     * This implementation does not trigger {@link MailAddressResolver} extension point.
+     * @return User address or null if resolution failed
+     */
+    public static String resolveFast(User u) {
+
         String extractedAddress = extractAddressFromId(u.getFullName());
         if (extractedAddress != null)
             return extractedAddress;
@@ -125,8 +140,9 @@ public abstract class MailAddressResolver implements ExtensionPoint {
                 return m.group(1)+ds; // user+defaultSuffix
 
             return u.getId()+ds;
-        } else
-            return null;
+        }
+
+        return null;
     }
 
     /**

--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -532,6 +532,15 @@ public class Mailer extends Notifier {
             return MailAddressResolver.resolve(user);
         }
 
+        public String getConfiguredAddress() {
+            if(hasExplicitlyConfiguredAddress()) {
+                return emailAddress;
+            }
+
+            // try the inference logic
+            return MailAddressResolver.resolveFast(user);
+        }
+
         /**
          * Has the user configured a value explicitly (true), or is it inferred (false)?
          */

--- a/src/main/resources/hudson/tasks/Mailer/UserProperty/config.jelly
+++ b/src/main/resources/hudson/tasks/Mailer/UserProperty/config.jelly
@@ -26,6 +26,6 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%E-mail address}"
     description="${%description}">
-    <f:textbox name="email.address" value="${instance.address}"/>
+    <f:textbox name="email.address" value="${instance.configuredAddress}"/>
   </f:entry>
 </j:jelly>

--- a/src/test/java/hudson/tasks/MailAddressResolverTest.java
+++ b/src/test/java/hudson/tasks/MailAddressResolverTest.java
@@ -1,18 +1,177 @@
-package hudson.tasks;
- 
-import hudson.model.User;
-import hudson.tasks.Mailer.UserProperty;
-import org.jvnet.hudson.test.Bug;
-import org.jvnet.hudson.test.HudsonTestCase;
- 
-/**
- * @author Kohsuke Kawaguchi
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2012-2013 Kohsuke Kawaguchi, Red Hat, Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
-public class MailAddressResolverTest extends HudsonTestCase {
+package hudson.tasks;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import hudson.ExtensionList;
+import hudson.model.Hudson;
+import hudson.model.User;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import jenkins.model.Jenkins;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.Bug;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * @author Kohsuke Kawaguchi, ogondza
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( {MailAddressResolver.class, Mailer.class, Mailer.DescriptorImpl.class})
+public class MailAddressResolverTest {
+
+    private User user;
+    private Jenkins jenkins;
+    private Mailer.DescriptorImpl descriptor;
+
+    @Before
+    public void setUp() throws Exception {
+
+        jenkins = PowerMockito.mock(Hudson.class);
+
+        user = PowerMockito.mock(User.class);
+        when(user.getFullName()).thenReturn("Full name");
+        when(user.getId()).thenReturn("user_id");
+
+        PowerMockito.spy(Mailer.class);
+        descriptor = PowerMockito.mock(Mailer.DescriptorImpl.class);
+        PowerMockito.doReturn(descriptor).when(Mailer.class, "descriptor");
+    }
+
+    @Test
+    public void nameAlreadyIsAnAddress() throws Exception {
+
+        validateUserPropertyAddress("user@example.com", "user@example.com", "");
+    }
+
+    @Test
+    public void nameContainsAddress() throws Exception {
+
+        validateUserPropertyAddress("user@example.com", "User Name <user@example.com>", "");
+    }
+
     @Bug(5164)
-    public void test5164() {
-        Mailer.descriptor().setDefaultSuffix("@example.com");
-        String a = User.get("DOMAIN\\user").getProperty(UserProperty.class).getAddress();
-        assertEquals("user@example.com",a);
+    @Test
+    public void test5164() throws Exception {
+
+        validateUserPropertyAddress("user@example.com", "DOMAIN\\user", "@example.com");
+    }
+
+    private void validateUserPropertyAddress(
+            String address, String username, String suffix
+    ) throws Exception {
+
+        PowerMockito.when(descriptor.getDefaultSuffix()).thenReturn(suffix);
+
+        PowerMockito.when(user.getFullName()).thenReturn(username);
+        PowerMockito.when(user.getId()).thenReturn(username.replace('\\','_'));
+
+        String a = new UserPropertyMock(user, null).getConfiguredAddress();
+        assertEquals(address, a);
+    }
+
+    private static class UserPropertyMock extends Mailer.UserProperty {
+
+        public UserPropertyMock(User user, String emailAddress) {
+            super(emailAddress);
+            this.user = user;
+        }
+    }
+
+    @Test
+    public void doNotResolveWhenUsingFastResolution() throws Exception {
+
+        final MailAddressResolver resolver = mockResolver();
+
+        configure(resolver);
+
+        final String address = MailAddressResolver.resolveFast(user);
+
+        verify(resolver, never()).findMailAddressFor(user);
+
+        assertNull(address);
+    }
+
+    @Test
+    public void doResolveWhenNotUsingFastResolution() throws Exception {
+
+        final MailAddressResolver resolver = mockResolver();
+        PowerMockito.when(resolver.findMailAddressFor(user)).thenReturn("a@b.c");
+
+        configure(resolver);
+
+        final String address = MailAddressResolver.resolve(user);
+
+        verify(resolver, times(1)).findMailAddressFor(user);
+
+        assertEquals("a@b.c", address);
+    }
+
+    private MailAddressResolver mockResolver() {
+
+        return PowerMockito.mock(MailAddressResolver.class);
+    }
+
+    private void configure(final MailAddressResolver... resolvers) throws Exception {
+
+        PowerMockito.spy(MailAddressResolver.class);
+
+        PowerMockito.doReturn(new MockExtensionList(jenkins, resolvers))
+            .when(MailAddressResolver.class, "all")
+        ;
+    }
+
+    private static class MockExtensionList extends ExtensionList<MailAddressResolver> {
+
+        private List<MailAddressResolver> extensions;
+
+        public MockExtensionList(
+                final Jenkins jenkins,
+                final MailAddressResolver[] resolvers
+        ) {
+
+            super(jenkins, MailAddressResolver.class);
+
+            extensions = Arrays.asList(resolvers);
+        }
+
+        @Override
+        public Iterator<MailAddressResolver> iterator() {
+
+            return extensions.iterator();
+        }
     }
 }


### PR DESCRIPTION
Prohibit /user/&lt;username&gt;/configure/ to invoke resolvers while loading form.

https://issues.jenkins-ci.org/browse/JENKINS-16390
