### PR TITLE
Option to restrict mail to be sent only for failed builds

### DIFF
--- a/src/main/resources/hudson/tasks/Mailer/config.jelly
+++ b/src/main/resources/hudson/tasks/Mailer/config.jelly
@@ -30,6 +30,9 @@ THE SOFTWARE.
   <f:entry field="notifyEveryUnstableBuild" title="">
     <f:checkbox title="${%Send e-mail for every unstable build}" default="true" />
   </f:entry>
+  <f:entry field="restrictToFailures" title="">
+    <f:checkbox title="${%Send only for failed builds}" />
+  </f:entry>
   <f:entry field="sendToIndividuals" title="">
     <f:checkbox title="${%Send separate e-mails to individuals who broke the build}" />
   </f:entry>

--- a/src/main/resources/hudson/tasks/Mailer/config_pt_BR.properties
+++ b/src/main/resources/hudson/tasks/Mailer/config_pt_BR.properties
@@ -24,5 +24,5 @@ Recipients=Destinat\u00E1rios
 description=Lista de endere\u00e7os separados por espa\u00e7os em branco. E-mail ser\u00e1 enviado quando uma constru\u00e7\u00e3o falhar.
 Send\ e-mail\ for\ every\ unstable\ build=Enviar e-mail para todas as constru\u00e7\u00f5es inst\u00e1veis
 Send\ separate\ e-mails\ to\ individuals\ who\ broke\ the\ build=Enviar e-mails separados para os indiv\u00edduos que danificaram a constru\u00e7\u00e3o
-
+Send\ only\ for\ failed\ builds=Enviar apenas para constru\u00e7\u00f5es que falharem
 

--- a/src/main/resources/hudson/tasks/Mailer/help-restrictToFailures.html
+++ b/src/main/resources/hudson/tasks/Mailer/help-restrictToFailures.html
@@ -1,0 +1,4 @@
+<div>
+  If this option is checked, the notification e-mail will be sent only if the build status
+  is "FAILURE".
+</div>

--- a/src/main/resources/hudson/tasks/Mailer/help-restrictToFailures_pt_BR.html
+++ b/src/main/resources/hudson/tasks/Mailer/help-restrictToFailures_pt_BR.html
@@ -1,0 +1,4 @@
+<div>
+  Se esta op&#231;&#227;o estiver marcada, o e-mail de notifica&#231;&#227;o ser&#225; 
+  enviado apenas se o estado da constru&#231;&#227;o for "FALHOU"
+</div>

--- a/src/test/java/hudson/tasks/MailerTest.java
+++ b/src/test/java/hudson/tasks/MailerTest.java
@@ -53,7 +53,7 @@ public class MailerTest extends HudsonTestCase {
         // create a project to simulate a build failure
         FreeStyleProject project = createFreeStyleProject();
         project.getBuildersList().add(new FailureBuilder());
-        Mailer m = new Mailer(recipient, false, false);
+        Mailer m = new Mailer(recipient, false, false, false);
         project.getPublishersList().add(m);
 
         project.scheduleBuild2(0).get();
@@ -66,10 +66,10 @@ public class MailerTest extends HudsonTestCase {
 
     @Email("http://www.nabble.com/email-recipients-disappear-from-freestyle-job-config-on-save-to25479293.html")
     public void testConfigRoundtrip() throws Exception {
-        Mailer m = new Mailer("kk@kohsuke.org", false, true);
+        Mailer m = new Mailer("kk@kohsuke.org", false, true, false);
         verifyRoundtrip(m);
 
-        m = new Mailer("", true, false);
+        m = new Mailer("", true, false, false);
         verifyRoundtrip(m);
     }
 
@@ -129,7 +129,7 @@ public class MailerTest extends HudsonTestCase {
         // not configured.
         assertNull(new CleanJenkinsLocationConfiguration().getUrl());
         
-        Mailer m = new Mailer("", true, false);
+        Mailer m = new Mailer("", true, false, false);
         FreeStyleProject p = createFreeStyleProject();
         p.getPublishersList().add(m);
         WebClient wc = new WebClient();


### PR DESCRIPTION
In my company there are lots of instable tests and receive a lot of e-mails with build become unstable/build back to normal is very annoying.
This option restrict to only failed builds.
