### PR TITLE
Handle case from JENKINS-16332

### DIFF
--- a/src/test/java/hudson/tasks/MailAddressResolverTest.java
+++ b/src/test/java/hudson/tasks/MailAddressResolverTest.java
@@ -83,6 +83,20 @@ public class MailAddressResolverTest {
         validateUserPropertyAddress("user@example.com", "User Name <user@example.com>", "");
     }
 
+    @Bug(16332)
+    @Test
+    public void nameContainsAddressWithUnderscores() throws Exception {
+
+        validateUserPropertyAddress("user@example.com", "User Name _user@example.com_", "");
+    }
+
+    @Bug(16332)
+    @Test
+    public void nameContainsAddressWithUnderscoresInNameToo() throws Exception {
+
+        validateUserPropertyAddress("user_name@example.com", "User Name _user_name@example.com_", "");
+    }    
+
     @Bug(5164)
     @Test
     public void test5164() throws Exception {


### PR DESCRIPTION
Added ability to handle case where we get full name with email like "Firstname Lastname _username@domain.com_", currently MailAddressResolver takes the following path:

```
 if(u.getFullName().contains("@"))
            // this already looks like an e-mail ID
            return u.getFullName();
```

Which results in an invalid email address that is just the same "Firstname Lastname _username@domain.com_".

Added code to extractAddressFromId to check for this case and return the correct email address.

Added two tests that verify the new code works.
