### PR TITLE
Making it buildable with jdk8 and fixed findbugs issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.609.1</version>
+    <version>1.580.1</version>
   </parent>
   <artifactId>mailer</artifactId>
   <packaging>hpi</packaging>
@@ -88,6 +88,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>${findbugs-maven-plugin.version}</version>
@@ -103,6 +112,27 @@
             <goals>
               <goal>check</goal> 
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.13</version>
+        <executions>
+          <execution>
+            <id>check-java-api</id>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <signature>
+                <groupId>org.codehaus.mojo.signature</groupId>
+                <artifactId>java16</artifactId>
+                <version>1.1</version>
+              </signature>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.577</version>
+    <version>1.609.1</version>
   </parent>
   <artifactId>mailer</artifactId>
   <packaging>hpi</packaging>
@@ -18,9 +18,9 @@
     </license>
   </licenses>
   <properties>
-    <powermock.version>1.4.12</powermock.version>
+    <powermock.version>1.6.2</powermock.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>  
-    <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
+    <findbugs-maven-plugin.version>3.0.2</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
   </properties>
   <dependencies>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.8.5</version>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/cli/MailCommand.java
+++ b/src/main/java/hudson/cli/MailCommand.java
@@ -46,7 +46,7 @@ public class MailCommand extends CLICommand {
     }
 
     protected int run() throws Exception {
-        Jenkins.getInstance().checkPermission(Item.CONFIGURE);
+        Jenkins.getActiveInstance().checkPermission(Item.CONFIGURE);
         Transport.send(new MimeMessage(Mailer.descriptor().createSession(),stdin));
         return 0;
     }

--- a/src/main/java/hudson/cli/MailCommand.java
+++ b/src/main/java/hudson/cli/MailCommand.java
@@ -46,8 +46,13 @@ public class MailCommand extends CLICommand {
     }
 
     protected int run() throws Exception {
-        Jenkins.getActiveInstance().checkPermission(Item.CONFIGURE);
-        Transport.send(new MimeMessage(Mailer.descriptor().createSession(),stdin));
-        return 0;
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins != null) {
+            jenkins.checkPermission(Item.CONFIGURE);
+            Transport.send(new MimeMessage(Mailer.descriptor().createSession(),stdin));
+            return 0;
+        } else {
+            throw new IllegalStateException("Jenkins is not active.");
+        }
     }
 }

--- a/src/main/java/hudson/cli/MailCommand.java
+++ b/src/main/java/hudson/cli/MailCommand.java
@@ -46,6 +46,7 @@ public class MailCommand extends CLICommand {
     }
 
     protected int run() throws Exception {
+        // TODO 1.590+ Jenkins.getActiveInstance
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins != null) {
             jenkins.checkPermission(Item.CONFIGURE);

--- a/src/main/java/hudson/tasks/MailSender.java
+++ b/src/main/java/hudson/tasks/MailSender.java
@@ -357,6 +357,7 @@ public class MailSender {
             if (build instanceof AbstractBuild && address.startsWith("upstream-individuals:")) {
                 // people who made a change in the upstream
                 String projectName = address.substring("upstream-individuals:".length());
+                // TODO 1.590+ Jenkins.getActiveInstance
                 final Jenkins jenkins = Jenkins.getInstance();
                 if (jenkins == null) {
                     listener.getLogger().println("Jenkins is not ready. Cannot retrieve project "+projectName);

--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -221,6 +221,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
     public static DescriptorImpl DESCRIPTOR;
 
     public static DescriptorImpl descriptor() {
+        // TODO 1.590+ Jenkins.getActiveInstance
         final Jenkins jenkins = Jenkins.getInstance();
         if (jenkins == null) {
             throw new IllegalStateException("Jenkins instance is not ready");
@@ -541,6 +542,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
                 @QueryParameter boolean useSsl, @QueryParameter String smtpPort, @QueryParameter String charset,
                 @QueryParameter String sendTestMailTo) throws IOException, ServletException, InterruptedException {
             try {
+                // TODO 1.590+ Jenkins.getActiveInstance
                 final Jenkins jenkins = Jenkins.getInstance();
                 if (jenkins == null) {
                     throw new IOException("Jenkins instance is not ready");

--- a/src/main/java/jenkins/plugins/mailer/tasks/MailAddressFilter.java
+++ b/src/main/java/jenkins/plugins/mailer/tasks/MailAddressFilter.java
@@ -149,6 +149,7 @@ public abstract class MailAddressFilter implements Describable<MailAddressFilter
 
     @Override
     public MailAddressFilterDescriptor getDescriptor() {
+        // TODO 1.590+ Jenkins.getActiveInstance
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins != null) {
             return (MailAddressFilterDescriptor)jenkins.getDescriptor(getClass());
@@ -161,6 +162,7 @@ public abstract class MailAddressFilter implements Describable<MailAddressFilter
      * Returns all the registered {@link MailAddressFilter} descriptors
      */
     public static DescriptorExtensionList<MailAddressFilter,MailAddressFilterDescriptor> all() {
+        // TODO 1.590+ Jenkins.getActiveInstance
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins != null) {
             return jenkins.<MailAddressFilter, MailAddressFilterDescriptor>getDescriptorList(MailAddressFilter.class);
@@ -170,6 +172,7 @@ public abstract class MailAddressFilter implements Describable<MailAddressFilter
     }
     
     public static ExtensionList<MailAddressFilter> allExtensions() {
+        // TODO 1.590+ Jenkins.getActiveInstance
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins != null) {
             return jenkins.getExtensionList(MailAddressFilter.class);

--- a/src/main/java/jenkins/plugins/mailer/tasks/MailAddressFilter.java
+++ b/src/main/java/jenkins/plugins/mailer/tasks/MailAddressFilter.java
@@ -34,6 +34,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Hudson;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -148,18 +149,18 @@ public abstract class MailAddressFilter implements Describable<MailAddressFilter
 
     @Override
     public MailAddressFilterDescriptor getDescriptor() {
-        return (MailAddressFilterDescriptor)Hudson.getInstance().getDescriptor(getClass());
+        return (MailAddressFilterDescriptor)Jenkins.getActiveInstance().getDescriptor(getClass());
     }
     
     /**
      * Returns all the registered {@link MailAddressFilter} descriptors
      */
     public static DescriptorExtensionList<MailAddressFilter,MailAddressFilterDescriptor> all() {
-        return Hudson.getInstance().<MailAddressFilter,MailAddressFilterDescriptor>getDescriptorList(MailAddressFilter.class);
+        return Jenkins.getActiveInstance().<MailAddressFilter,MailAddressFilterDescriptor>getDescriptorList(MailAddressFilter.class);
     }
     
     public static ExtensionList<MailAddressFilter> allExtensions() {
-        return Hudson.getInstance().getExtensionList(MailAddressFilter.class);
+        return Jenkins.getActiveInstance().getExtensionList(MailAddressFilter.class);
     }
 
     private static final Logger LOGGER = Logger.getLogger(MailAddressFilter.class.getName());

--- a/src/main/java/jenkins/plugins/mailer/tasks/MailAddressFilter.java
+++ b/src/main/java/jenkins/plugins/mailer/tasks/MailAddressFilter.java
@@ -149,18 +149,33 @@ public abstract class MailAddressFilter implements Describable<MailAddressFilter
 
     @Override
     public MailAddressFilterDescriptor getDescriptor() {
-        return (MailAddressFilterDescriptor)Jenkins.getActiveInstance().getDescriptor(getClass());
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins != null) {
+            return (MailAddressFilterDescriptor)jenkins.getDescriptor(getClass());
+        } else {
+            throw new IllegalStateException("Jenkins is not active.");
+        }
     }
     
     /**
      * Returns all the registered {@link MailAddressFilter} descriptors
      */
     public static DescriptorExtensionList<MailAddressFilter,MailAddressFilterDescriptor> all() {
-        return Jenkins.getActiveInstance().<MailAddressFilter,MailAddressFilterDescriptor>getDescriptorList(MailAddressFilter.class);
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins != null) {
+            return jenkins.<MailAddressFilter, MailAddressFilterDescriptor>getDescriptorList(MailAddressFilter.class);
+        } else {
+            throw new IllegalStateException("Jenkins is not active.");
+        }
     }
     
     public static ExtensionList<MailAddressFilter> allExtensions() {
-        return Jenkins.getActiveInstance().getExtensionList(MailAddressFilter.class);
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins != null) {
+            return jenkins.getExtensionList(MailAddressFilter.class);
+        } else {
+            throw new IllegalStateException("Jenkins is not active.");
+        }
     }
 
     private static final Logger LOGGER = Logger.getLogger(MailAddressFilter.class.getName());

--- a/src/test/java/hudson/tasks/MailAddressResolverTest.java
+++ b/src/test/java/hudson/tasks/MailAddressResolverTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Bug;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -51,6 +52,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest( {MailAddressResolver.class, Mailer.class, Mailer.DescriptorImpl.class})
+@PowerMockIgnore({"javax.security.*", "javax.xml.*"})
 public class MailAddressResolverTest {
 
     private User user;

--- a/src/test/java/jenkins/plugins/mailer/tasks/MailAddressFilterTest.java
+++ b/src/test/java/jenkins/plugins/mailer/tasks/MailAddressFilterTest.java
@@ -45,6 +45,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -53,6 +54,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ MailAddressFilter.class, AbstractBuild.class, BuildListener.class })
+@PowerMockIgnore({"javax.security.*", "javax.xml.*"})
 public class MailAddressFilterTest {
 
     private Hudson jenkins;


### PR DESCRIPTION
The change could only require 1.580.1 but then I wouldn't get to use the wonderful ```Jenkins.getActiveInstance()```

@reviewbybees 