### PR TITLE
Update Mailer.java

### DIFF
--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -556,7 +556,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
                 MimeMessage msg = new MimeMessage(createSession(smtpServer, smtpPort, useSsl, smtpAuthUserName, smtpAuthPasswordSecret));
                 msg.setSubject(Messages.Mailer_TestMail_Subject(testEmailCount.incrementAndGet()), charset);
                 msg.setText(Messages.Mailer_TestMail_Content(testEmailCount.get(), jenkins.getDisplayName()), charset);
-                msg.setFrom(stringToAddress(adminAddress, charset));
+                msg.setFrom(stringToAddress(replyToAddress, charset));
                 if (StringUtils.isNotBlank(replyToAddress)) {
                     msg.setReplyTo(new Address[]{stringToAddress(replyToAddress, charset)});
                 }


### PR DESCRIPTION
fixed the method "hudson.tasks.Mailer$DescriptorImpl.doSendTestMail" ;
when admin's mail adress not the SMTP's sender ,the error is:

```
 com.sun.mail.smtp.SMTPSendFailedException: 553 Mail from must equal authorized user
;
  nested exception is:
    com.sun.mail.smtp.SMTPSenderFailedException: 553 Mail from must equal authorized user

    at com.sun.mail.smtp.SMTPTransport.issueSendCommand(SMTPTransport.java:2057)
    at com.sun.mail.smtp.SMTPTransport.mailFrom(SMTPTransport.java:1580)
    at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1097)
    at javax.mail.Transport.send0(Transport.java:195)
    at javax.mail.Transport.send(Transport.java:124)
    at hudson.tasks.Mailer$DescriptorImpl.doSendTestMail(Mailer.java:566)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:298)
    at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:161)
    at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:96)
    at org.kohsuke.stapler.MetaClass$1.doDispatch(MetaClass.java:121)
    at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:53)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:746)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:876)
    at org.kohsuke.stapler.MetaClass$6.doDispatch(MetaClass.java:249)
    at org.kohsuk
```
