### PR TITLE
[JENKINS-32301] Support more than one Reply-To Address

### DIFF
--- a/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
+++ b/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
@@ -24,6 +24,7 @@
  */
 package jenkins.plugins.mailer.tasks;
 
+import com.google.common.collect.Lists;
 import hudson.model.TaskListener;
 import hudson.remoting.Base64;
 import hudson.tasks.Mailer;
@@ -49,8 +50,10 @@ import javax.mail.internet.MimeUtility;
 
 import java.io.UnsupportedEncodingException;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
@@ -68,7 +71,7 @@ public class MimeMessageBuilder {
     private TaskListener listener;
     private String defaultSuffix;
     private String from;
-    private String replyTo;
+    private Set<InternetAddress> replyTo = new LinkedHashSet<InternetAddress>();
     private String subject;
     private String body;
     private AddressFilter recipientFilter;
@@ -81,8 +84,13 @@ public class MimeMessageBuilder {
             JenkinsLocationConfiguration jlc = JenkinsLocationConfiguration.get();
             if (jlc != null) {
                 defaultSuffix = Mailer.descriptor().getDefaultSuffix();
-                from = jlc.getAdminAddress();
-                replyTo = Mailer.descriptor().getReplyToAddress();
+                from = JenkinsLocationConfiguration.get().getAdminAddress();
+                final String rto = Mailer.descriptor().getReplyToAddress();
+                try {
+                    replyTo.addAll(toNormalizedAddresses(rto));
+                } catch(UnsupportedEncodingException e) {
+                    logError("Unable to parse Reply-To Addresses " + rto, e);
+                }
             }
         }
     }
@@ -113,9 +121,26 @@ public class MimeMessageBuilder {
     }
 
     public MimeMessageBuilder setReplyTo(@Nonnull String replyTo) {
-        this.replyTo = replyTo;
+        try {
+            final List<InternetAddress> addresses = toNormalizedAddresses(replyTo);
+            // Done after to leave the current value untouched if there is a parsing error.
+            this.replyTo.clear();
+            this.replyTo.addAll(addresses);
+        } catch(UnsupportedEncodingException e) {
+            logError("Unable to parse Reply-To Addresses " + replyTo, e);
+        }
         return this;
     }
+
+    public MimeMessageBuilder addReplyTo(@Nonnull String replyTo) {
+        try {
+            this.replyTo.addAll(toNormalizedAddresses(replyTo));
+        } catch(UnsupportedEncodingException e) {
+            logError("Unable to parse Reply-To Addresses " + replyTo, e);
+        }
+        return this;
+    }
+
 
     public MimeMessageBuilder setSubject(@Nonnull String subject) {
         this.subject = subject;
@@ -178,8 +203,8 @@ public class MimeMessageBuilder {
         addBody(msg);
         addRecipients(msg);
 
-        if (StringUtils.isNotBlank(replyTo)) {
-            msg.setReplyTo(new Address[]{toNormalizedAddress(replyTo)});
+        if (!replyTo.isEmpty()) {
+            msg.setReplyTo(toAddressArray(replyTo));
         }
         return msg;
     }
@@ -197,6 +222,15 @@ public class MimeMessageBuilder {
             }
             msg.setHeader("X-Instance-Identity", encodedIdentity);
         }
+    }
+
+    private static Address[] toAddressArray(Collection<InternetAddress> c) {
+        if (c == null || c.isEmpty()) {
+            return new Address[0];
+        }
+        final Address[] addresses = new Address[c.size()];
+        c.toArray(addresses);
+        return addresses;
     }
 
     public static void setInReplyTo(@Nonnull MimeMessage msg, @Nonnull String inReplyTo) throws MessagingException {
@@ -234,17 +268,28 @@ public class MimeMessageBuilder {
         addRecipients(msg, cc, Message.RecipientType.CC);
         addRecipients(msg, bcc, Message.RecipientType.BCC);
     }
+
     private void addRecipients(MimeMessage msg, Set<InternetAddress> recipientList, Message.RecipientType recipientType) throws UnsupportedEncodingException, MessagingException {
         if (recipientList.isEmpty()) {
             return;
         }
+        final Collection<InternetAddress> recipients = recipientFilter != null ? recipientFilter.apply(recipientList) : recipientList;
+        msg.setRecipients(recipientType, toAddressArray(recipients));
+    }
 
-        if (recipientFilter != null) {
-            Set<InternetAddress> filteredList = recipientFilter.apply(recipientList);
-            msg.setRecipients(recipientType, filteredList.toArray(new InternetAddress[filteredList.size()]));
-        } else {
-            msg.setRecipients(recipientType, recipientList.toArray(new InternetAddress[recipientList.size()]));
+    private List<InternetAddress> toNormalizedAddresses(String addresses) throws UnsupportedEncodingException {
+        final List<InternetAddress> list = Lists.newLinkedList();
+        if (StringUtils.isNotBlank(addresses)) {
+            StringTokenizer tokens = new StringTokenizer(addresses, " \t\n\r\f,");
+            while (tokens.hasMoreTokens()) {
+                String addressToken = tokens.nextToken();
+                InternetAddress internetAddress = toNormalizedAddress(addressToken);
+                if (internetAddress != null) {
+                    list.add(internetAddress);
+                }
+            }
         }
+        return list;
     }
 
     private InternetAddress toNormalizedAddress(String address) throws UnsupportedEncodingException {

--- a/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
+++ b/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
@@ -60,6 +60,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
+ * Builder for {@link MimeMessage}. This class is NOT thread-safe.
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 public class MimeMessageBuilder {


### PR DESCRIPTION
See [JENKINS-32301](https://issues.jenkins-ci.org/browse/JENKINS-32301)

Some additional refactoring of `MimeMessageBuilderTest` included.

@reviewbybees 