### PR TITLE
Update mailer to use new display-url-api for user facing page links

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,15 @@
   </licenses>
   <properties>
     <powermock.version>1.6.2</powermock.version>
-    <jenkins.version>1.580.1</jenkins.version>
-    <java.level>6</java.level>
+    <java.level>7</java.level>
+    <jenkins.version>1.625.3</jenkins.version>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>display-url-api</artifactId>
+      <version>0.2</version>
+    </dependency>
     <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>mail</artifactId>


### PR DESCRIPTION
Updates mailer to use the `DisplayURLProvider` so that Blue Ocean can send its own URLs instead of classic.

Depends on #28 so that we can depend on a recent Jenkins snapshot that contains `URLFactory`

Waiting on https://issues.jenkins-ci.org/browse/HOSTING-179

@jenkinsci/code-reviewers 