### PR TITLE
[JENKINS-39976] Add line break before separator line even if there are no changesets found

### DIFF
--- a/src/main/java/hudson/tasks/MailSender.java
+++ b/src/main/java/hudson/tasks/MailSender.java
@@ -267,10 +267,9 @@ public class MailSender {
                     buf.append('\n');
                 }
             }
-            buf.append('\n');
         }
 
-        buf.append("------------------------------------------\n");
+        buf.append("\n------------------------------------------\n");
 
         try {
             // Restrict max log size to avoid sending enormous logs over email.

--- a/src/main/java/hudson/tasks/MailSender.java
+++ b/src/main/java/hudson/tasks/MailSender.java
@@ -267,6 +267,7 @@ public class MailSender {
                     buf.append('\n');
                 }
             }
+            buf.append('\n');
         }
 
         buf.append("\n------------------------------------------\n");


### PR DESCRIPTION
Otherwise separator line will stick to the build URL, rendering to unusable link