### PR TITLE
DO NOT MERGE: Is there any way to disable/hide jenkins log generated from mailer plugin.

### DIFF
--- a/issue
+++ b/issue
@@ -1,0 +1,3 @@
+Is there any way to disable/hide jenkins log generated from mailer plugin.
+For eg. "Sending e-mails to: abc@aa.com xyz@xx.com"
+I want to disable "Sending e-mails to: abc@aa.com xyz@xx.com" this, So user who have read permission should not see my email address.


### PR DESCRIPTION
For eg. "Sending e-mails to: abc@aa.com xyz@xx.com"
I want to disable/hide "Sending e-mails to: abc@aa.com xyz@xx.com"
this, So user who have read permission should not see my email address.

Since there is no option to raise a issue, so i raised a PR.