### PR TITLE
Mailer: fix missing getter for smtpHost property

### DIFF
--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -459,7 +459,11 @@ public class Mailer extends Notifier implements SimpleBuildStep {
         public String getSmtpPort() {
         	return smtpPort;
         }
-        
+
+        public String getSmtpHost() {
+            return smtpHost;
+        }
+
         public String getCharset() {
         	String c = charset;
         	if (c == null || c.length() == 0)	c = "UTF-8";


### PR DESCRIPTION
required for configuration-as-code

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>