### PR TITLE
[JENKINS-37812] No notification re. failed job if agent goes offline during the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,8 @@
   </licenses>
   <properties>
     <java.level>7</java.level>
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>1.642.3</jenkins.version>
+    <workflow.version>2.6</workflow.version>
   </properties>
   <dependencies>
     <dependency>
@@ -86,6 +87,43 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- JENKINS-37812. Dependencies for test -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>1.21</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>annotation-indexer</artifactId>
+      <version>1.9</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -29,15 +29,13 @@ import static hudson.Util.fixEmptyAndTrim;
 
 import hudson.EnvVars;
 import hudson.Extension;
-import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
 import hudson.RestrictedSince;
 import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.model.Run;
-import hudson.model.TaskListener;
+import hudson.model.BuildListener;
 import hudson.model.User;
 import hudson.model.UserPropertyDescriptor;
 import jenkins.plugins.mailer.tasks.i18n.Messages;
@@ -83,7 +81,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 
 import jenkins.model.Jenkins;
-import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -93,7 +90,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  *
  * @author Kohsuke Kawaguchi
  */
-public class Mailer extends Notifier implements SimpleBuildStep {
+public class Mailer extends Notifier {
     protected static final Logger LOGGER = Logger.getLogger(Mailer.class.getName());
 
     /**
@@ -136,7 +133,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+    public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         if(debug)
             listener.getLogger().println("Running mailer");
         // substitute build parameters
@@ -169,6 +166,8 @@ public class Mailer extends Notifier implements SimpleBuildStep {
                 return false;
             }
         }.run(build,listener);
+
+        return true;
     }
 
     /**

--- a/src/test/java/hudson/tasks/MailerTest.java
+++ b/src/test/java/hudson/tasks/MailerTest.java
@@ -56,6 +56,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -283,7 +284,7 @@ public class MailerTest {
         Mailbox inbox = getMailbox(RECIPIENT);
         inbox.clear();
         WorkflowRun b = rule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
-        assertEquals(1, inbox.size());
+        assertThat("One email should have been sent", inbox, hasSize(1));
         assertEquals("Build failed in Jenkins: " + b.getFullDisplayName(), inbox.get(0).getSubject());
         assertThat(rule.getLog(b), containsString("Sending e-mails to"));
     }
@@ -388,7 +389,7 @@ public class MailerTest {
 
         void checkSendingContent() throws Exception {
             Mailbox inbox = getMailbox(RECIPIENT);
-            assertEquals(1, inbox.size());
+            assertThat("One email should have been sent", inbox, hasSize(1));
             assertThat(log, containsString("Sending e-mails to"));
         }
     }


### PR DESCRIPTION
See [JENKINS-37812](https://issues.jenkins-ci.org/browse/JENKINS-37812)

Class [`Mailer`](https://github.com/jenkinsci/mailer-plugin/blob/master/src/main/java/hudson/tasks/Mailer.java#L96) is implementing the interface `SimpleBuildStep`. Since the workspace is only used to format the email sent, it's not entirely needed to fail if the workspace is not retrieved. With this PR the email notifying that the build failed will be sent even if the agent goes offline.

Added a test that checks that the email is sent and fails with the precious code.

@reviewbybees @alecharp 