### PR TITLE
Java 11 readiness: build both on JDK8 and JDK11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,1 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.42</version>
+    <version>3.43</version>
     <relativePath />
   </parent>
   
@@ -23,19 +23,18 @@
   </licenses>
   <properties>
     <java.level>8</java.level>
-    <jenkins.version>2.60.3</jenkins.version>
-    <workflow.version>2.6</workflow.version>
+    <jenkins.version>2.150.1</jenkins.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
-      <version>1.0</version>
+      <version>2.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.6</version>
+      <version>1.27</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -93,31 +92,49 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>${workflow.version}</version>
+      <version>2.32</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>${workflow.version}</version>
+      <version>2.15</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>${workflow.version}</version>
+      <version>2.67</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>${workflow.version}</version>
+      <version>2.30</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <version>2.33</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>2.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.17</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.21</version>
+      <version>1.58</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -132,7 +149,7 @@
       <dependency>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>symbol-annotation</artifactId>
-        <version>1.6</version>
+        <version>1.19</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>3.47</version>
     <relativePath />
   </parent>
   

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.32</version>
+    <version>3.42</version>
     <relativePath />
   </parent>
   
@@ -22,8 +22,8 @@
     </license>
   </licenses>
   <properties>
-    <java.level>7</java.level>
-    <jenkins.version>1.642.3</jenkins.version>
+    <java.level>8</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
     <workflow.version>2.6</workflow.version>
   </properties>
   <dependencies>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>1.4</version>
+      <version>2.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -123,10 +123,19 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.9</version>
+      <version>1.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci</groupId>
+        <artifactId>symbol-annotation</artifactId>
+        <version>1.6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -144,15 +144,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.jenkins-ci</groupId>
-        <artifactId>symbol-annotation</artifactId>
-        <version>1.19</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>


### PR DESCRIPTION
Making sure this plugin is constantly checked both building with JDK8 and JDK11.

This goes with the Jenkins Java 11 General Availability announcement made back in March, and we're making a pass to check plugins are looking good on a JDK11.

([to understand the Jenkinsfile content](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime))

@jenkinsci/java11-support 