### PR TITLE
[JENKINS-59172] - Use GitHub as a source of the plugin's documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
   <version>1.26-SNAPSHOT</version>
   <name>Jenkins Mailer Plugin</name>
   <description>This plugin allows you to configure email notifications for build results</description>
+  <url>https://github.com/jenkinsci/mailer-plugin</url>
   
-  <url>https://wiki.jenkins.io/display/JENKINS/Mailer</url>
   <licenses>
     <license>
       <name>The MIT license</name>


### PR DESCRIPTION
subj.

https://issues.jenkins-ci.org/browse/JENKINS-59172
