### PR TITLE
[JENKINS-58727] Warn only if no build result exists

### DIFF
--- a/src/main/java/hudson/tasks/MailSender.java
+++ b/src/main/java/hudson/tasks/MailSender.java
@@ -200,7 +200,10 @@ public class MailSender {
             }
         }
 
-        listener.getLogger().println("No mail will be sent out, as '" + build.getFullDisplayName() + "' does not have a result yet. Please make sure you set a proper result in case of pipeline/build scripts.");
+        if (build.getResult() == null) {
+            listener.getLogger().println("No mail will be sent out, as '" + build.getFullDisplayName() + "' does not have a result yet. Please make sure you set a proper result in case of pipeline/build scripts.");
+        }
+
         return null;
     }
 


### PR DESCRIPTION
Fixes [JENKINS-58727](https://issues.jenkins-ci.org/browse/JENKINS-58727)

This PR restricts the previously misleading warning

> No mail will be sent out, as 'XXX' does not have a result yet. Please make sure you set a proper result in case of pipeline/build scripts.

to situations where no build result was set at the point of this plugin's execution.