### PR TITLE
Fix CasC support for useTls

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,6 +28,9 @@ If your environment requires the use of SMTP authentication, specify the user na
 * **Use SSL**: Whether or not to use SSL for connecting to the SMTP server. 
 Defaults to port `465`. 
 Other advanced configurations can be done by setting system properties. See this document for possible values and effects.
+* **Use TLS**: Whether or not to use TLS for connecting to the SMTP server.
+Defaults to port `465`.
+Other advanced configurations can be done by setting system properties. See this document for possible values and effects.
 * **SMTP Port**: Port number for the mail server. 
 Leave it empty to use the default port for the protocol (`465` if using SSL, `25` if not).
 * **Reply-To Address**: Address to include in the `Reply-To` header.

--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -522,6 +522,10 @@ public class Mailer extends Notifier implements SimpleBuildStep {
         	return useSsl;
         }
 
+        public boolean getUseTls() {
+            return useTls;
+        }
+
         public String getSmtpPort() {
         	return smtpPort;
         }

--- a/src/test/java/jenkins/plugins/mailer/MailerJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/mailer/MailerJCasCCompatibilityTest.java
@@ -21,6 +21,7 @@ public class MailerJCasCCompatibilityTest extends RoundTripAbstractTest {
         assertEquals(String.format("Wrong SMTP host. Expected %s but received %s", "smtp.acme.com", descriptor.getSmtpHost()), "smtp.acme.com", descriptor.getSmtpHost());
         assertEquals(String.format("Wrong SMTP port. Expected %s but received %s", "808080", descriptor.getSmtpPort()), "808080", descriptor.getSmtpPort());
         assertTrue("SSL should be used", descriptor.getUseSsl());
+        assertTrue("TLS should be used", descriptor.getUseTls());
     }
 
     @Override

--- a/src/test/resources/jenkins/plugins/mailer/configuration-as-code.yaml
+++ b/src/test/resources/jenkins/plugins/mailer/configuration-as-code.yaml
@@ -9,3 +9,4 @@ unclassified:
     smtpHost: "smtp.acme.com"
     smtpPort: "808080"
     useSsl: true
+    useTls: true


### PR DESCRIPTION
I installed v1.31 of this plugin and found that the `useTls` option didn't appear in the CasC reference documentation, nor did it accept a YAML file with the option.

Adding a getter for the property seems to make this work.

Follows on from the work done in #76 