### PR TITLE
Resolve Mailer TODOs & warnings, fixing port data in README 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,10 +29,10 @@ If your environment requires the use of SMTP authentication, specify the user na
 Defaults to port `465`. 
 Other advanced configurations can be done by setting system properties. See this document for possible values and effects.
 * **Use TLS**: Whether or not to use TLS for connecting to the SMTP server.
-Defaults to port `465`.
+Defaults to port `587`.
 Other advanced configurations can be done by setting system properties. See this document for possible values and effects.
 * **SMTP Port**: Port number for the mail server. 
-Leave it empty to use the default port for the protocol (`465` if using SSL, `25` if not).
+Leave it empty to use the default port for the protocol (`587` if using TLS, `465` if using SSL, `25` if not using encryption).
 * **Reply-To Address**: Address to include in the `Reply-To` header.
 Up to version `1.16`, only one address is allowed, starting in version `1.17` more than one can be used.
 * **Charset**: character set to use to construct the message.

--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -408,8 +408,9 @@ public class Mailer extends Notifier implements SimpleBuildStep {
         }
 
         private static Authenticator getAuthenticator(final String smtpAuthUserName, final String smtpAuthPassword) {
-            if(smtpAuthUserName==null)
+            if(smtpAuthUserName == null) {
             	return null;
+            }
             return new Authenticator() {
                 @Override
                 protected PasswordAuthentication getPasswordAuthentication() {

--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -375,7 +375,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
                     props.put(SMTP_PORT_PROPERTY, port);
                     props.put(SMTP_SOCKETFACTORY_PORT_PROPERTY, port);
             	}
-            	if (props.getProperty(SMTP_SSL_ENABLE_PROPERTY)==null) {
+            	if (props.getProperty(SMTP_SSL_ENABLE_PROPERTY) == null) {
                     props.put(SMTP_SSL_ENABLE_PROPERTY, "true");
                     props.put("mail.smtp.ssl.checkserveridentity", true);
             	}

--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -370,7 +370,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
             	 * and thats done in mail sender, and it would be a bit of a hack to get it all to
             	 * coordinate, and we can make it work through setting mail.smtp properties.
             	 */
-            	if (props.getProperty(SMTP_SOCKETFACTORY_PORT_PROPERTY)==null) {
+            	if (props.getProperty(SMTP_SOCKETFACTORY_PORT_PROPERTY) == null) {
                     String port = smtpPort==null?"465":smtpPort;
                     props.put(SMTP_PORT_PROPERTY, port);
                     props.put(SMTP_SOCKETFACTORY_PORT_PROPERTY, port);

--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -237,11 +237,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
     public static DescriptorImpl DESCRIPTOR;
 
     public static DescriptorImpl descriptor() {
-        final Jenkins jenkins = Jenkins.getInstanceOrNull();
-        if (jenkins == null) {
-            throw new IllegalStateException("Jenkins instance is not ready");
-        }
-        return jenkins.getDescriptorByType(Mailer.DescriptorImpl.class);
+        return Jenkins.get().getDescriptorByType(Mailer.DescriptorImpl.class);
     }
 
     @Extension

--- a/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
+++ b/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
@@ -66,6 +66,7 @@ import java.util.logging.Logger;
 public class MimeMessageBuilder {
 
     private static final Logger LOGGER = Logger.getLogger(MimeMessageBuilder.class.getName());
+    private static final String PARSING_ADDRESS_ERROR_MESSAGE = "Unable to parse Reply-To Addresses ";
 
     private String charset = "UTF-8";
     private String mimeType = "text/plain";
@@ -89,7 +90,7 @@ public class MimeMessageBuilder {
             try {
                 replyTo.addAll(toNormalizedAddresses(rto));
             } catch(UnsupportedEncodingException e) {
-                logError("Unable to parse Reply-To Addresses " + rto, e);
+                logError(PARSING_ADDRESS_ERROR_MESSAGE + rto, e);
             }
         }
     }
@@ -126,7 +127,7 @@ public class MimeMessageBuilder {
             this.replyTo.clear();
             this.replyTo.addAll(addresses);
         } catch(UnsupportedEncodingException e) {
-            logError("Unable to parse Reply-To Addresses " + replyTo, e);
+            logError(PARSING_ADDRESS_ERROR_MESSAGE + replyTo, e);
         }
         return this;
     }
@@ -135,7 +136,7 @@ public class MimeMessageBuilder {
         try {
             this.replyTo.addAll(toNormalizedAddresses(replyTo));
         } catch(UnsupportedEncodingException e) {
-            logError("Unable to parse Reply-To Addresses " + replyTo, e);
+            logError(PARSING_ADDRESS_ERROR_MESSAGE + replyTo, e);
         }
         return this;
     }

--- a/src/test/java/hudson/tasks/MailerTest.java
+++ b/src/test/java/hudson/tasks/MailerTest.java
@@ -333,7 +333,7 @@ public class MailerTest {
     @LocalData
     public void testMigrateOldData() {
         Mailer.DescriptorImpl descriptor = Mailer.descriptor();
-        assertTrue("Mailer can not be found", descriptor != null);
+        assertNotNull("Mailer can not be found", descriptor);
         assertEquals(String.format("Authentication did not migrate properly. Username expected %s but received %s", "olduser", descriptor.getAuthentication().getUsername()), "olduser", descriptor.getAuthentication().getUsername());
         assertEquals(String.format("Charset did not migrate properly. Expected %s but received %s", "UTF-8", descriptor.getCharset()), "UTF-8", descriptor.getCharset());
         assertEquals(String.format("Default suffix did not migrate properly. Expected %s but received %s", "@mydomain.com", descriptor.getDefaultSuffix()), "@mydomain.com", descriptor.getDefaultSuffix());

--- a/src/test/java/jenkins/plugins/mailer/MailerJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/mailer/MailerJCasCCompatibilityTest.java
@@ -1,19 +1,20 @@
 package jenkins.plugins.mailer;
 
-import hudson.tasks.Mailer;
-import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import hudson.tasks.Mailer;
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
 
 public class MailerJCasCCompatibilityTest extends RoundTripAbstractTest {
 
     @Override
     protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
         Mailer.DescriptorImpl descriptor = Mailer.descriptor();
-        assertTrue("Mailer can not be found", descriptor != null);
+        assertNotNull("Mailer can not be found", descriptor);
         assertEquals(String.format("Wrong authentication. Username expected %s but received %s", "fakeuser", descriptor.getAuthentication().getUsername()), "fakeuser", descriptor.getAuthentication().getUsername());
         assertEquals(String.format("Wrong charset. Expected %s but received %s", "UTF-8", descriptor.getCharset()), "UTF-8", descriptor.getCharset());
         assertEquals(String.format("Wrong default suffix. Expected %s but received %s", "@mydomain.com", descriptor.getDefaultSuffix()), "@mydomain.com", descriptor.getDefaultSuffix());


### PR DESCRIPTION
On Mailer class:
+ Solved a TODO left in a previous commit on the SSL connection setup to SMTP server. So, `socketFactory` property was replaced by `mail.smtp.ssl.enable`. Additionally, added another property, `mail.smtp.ssl.checkserveridentity` in the SSL set-up, to enforce server identity check to avoid MITM attacks.
+ Also, addressed older TODOs about `Jenkins.getInstance` using the method recommended by Jenkins [docs](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstanceOrNull--) (`getInstanceOrNull`).
+ A couple of `@deprecated` annotations were on top of javaDoc blocks, hence they were being ignored. Moved them on top of the declaration and checked that javaDoc worked as expected.
+ Addressed a TODO about a try-with-resources for a BulkChange instance that was not properly closed in case of an exception.

Changed text in the README.adoc about the TLS default port (was wrong) and the SMTP port value depending on the configuration to make it clearer.

Changed MailerTest to assertNotNull instead of assertTrue on a not null validation.

Moved a repeated string in MimeMessageBuilder into a final const to use it were required