### PR TITLE
i18n: update the Italian translation

### DIFF
--- a/src/main/resources/hudson/tasks/Mailer/config_it.properties
+++ b/src/main/resources/hudson/tasks/Mailer/config_it.properties
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (C) 2004-2020, Sun Microsystems, Inc., Alessandro Menti
+# Copyright (C) 2020 Alessandro Menti
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +20,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-description=L''indirizzo di posta elettronica, ad esempio \
-  <tt>joe.chin@sun.com</tt>
-E-mail\ address=Indirizzo di posta elettronica
+description=Un elenco separato da spazi degli indirizzi dei destinatari. Si \
+  pu\ufffd far riferimento a dei parametri di compilazione con il costrutto \
+  <tt>$PARAMETRO</tt>. I messaggi di posta elettronica saranno inviati al \
+  fallimento di una compilazione, qualora questa diventi instabile oppure \
+  torni stabile.
+Recipients=Destinatari
+Send\ e-mail\ for\ every\ unstable\ build=Invia un messaggio di posta \
+  elettronica per ogni compilazione non stabile
+Send\ separate\ e-mails\ to\ individuals\ who\ broke\ the\ build=Invia dei \
+  messaggi di posta elettronica individuali a coloro che hanno causato il \
+  fallimento della compilazione

--- a/src/main/resources/hudson/tasks/Mailer/global_it.properties
+++ b/src/main/resources/hudson/tasks/Mailer/global_it.properties
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (C) 2004-2020, Sun Microsystems, Inc., Alessandro Menti
+# Copyright (C) 2020 Alessandro Menti
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +20,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-description=L''indirizzo di posta elettronica, ad esempio \
-  <tt>joe.chin@sun.com</tt>
-E-mail\ address=Indirizzo di posta elettronica
+Charset=Codifica
+Default\ user\ e-mail\ suffix=Suffisso predefinito per gli indirizzi di posta \
+  elettronica degli utenti
+E-mail\ Notification=Notifiche tramite posta elettronica
+Reply-To\ Address=Indirizzo "Rispondi a"
+SMTP\ Port=Porta SMTP
+SMTP\ server=Server SMTP
+Test\ configuration=Prova configurazione
+Test\ configuration\ by\ sending\ test\ e-mail=Prova la configurazione \
+  inviando un messaggio di posta elettronica di prova
+Test\ e-mail\ recipient=Destinatario messaggio di posta elettronica di prova
+Use\ SMTP\ Authentication=Utilizza autenticazione SMTP
+Use\ SSL=Utilizza SSL
+Use\ TLS=Utilizza TLS

--- a/src/main/resources/hudson/tasks/Mailer/help-authentication_it.html
+++ b/src/main/resources/hudson/tasks/Mailer/help-authentication_it.html
@@ -1,0 +1,5 @@
+<div>
+  Utilizza l'autenticazione SMTP durante l'invio dei messaggi di posta
+  elettronica. Se il proprio ambiente richiede l'utilizzo dell'autenticazione
+  SMTP, specificare qui il nome utente e la password da utilizzare.
+</div>

--- a/src/main/resources/hudson/tasks/Mailer/help-defaultSuffix_it.html
+++ b/src/main/resources/hudson/tasks/Mailer/help-defaultSuffix_it.html
@@ -1,0 +1,9 @@
+<div>
+  Se è possibile determinare automaticamente gli indirizzi di posta elettronica
+  dei propri utenti aggiungendo semplicemente un suffisso, lo si specifichi.
+  In caso contrario, si lasci il campo vuoto. Si noti che gli utenti possono
+  sempre eseguire l'override selettivo dell'indirizzo di posta elettronica. Ad
+  esempio, se questo campo è impostato a <tt>@acme.org</tt>, allora per
+  impostazione predefinita l'indirizzo di posta elettronica dell'utente
+  <tt>pippo</tt> sarà <tt>pippo@acme.org</tt>.
+</div>

--- a/src/main/resources/hudson/tasks/Mailer/help-sendToIndividuals_it.html
+++ b/src/main/resources/hudson/tasks/Mailer/help-sendToIndividuals_it.html
@@ -1,0 +1,12 @@
+<div>
+  Se quest'opzione è selezionata, il messaggio di posta elettronica di notifica
+  sarà inviato agli autori dei commit della compilazione fallita (in quanto si
+  assume che siano state tali modifiche a causare il fallimento della
+  compilazione).
+  <p>
+  Se sono stati specificati degli indirizzi di posta elettronica anche
+  nell'elenco dei destinatari, allora sia gli autori dei commit sia gli
+  indirizzi specificati riceveranno il messaggio di posta elettronica di
+  notifica. Se l'elenco dei destinatari è vuoto, solo gli autori riceveranno i
+  messaggi di posta elettronica.
+</div>

--- a/src/main/resources/hudson/tasks/Mailer/help-smtpPort_it.html
+++ b/src/main/resources/hudson/tasks/Mailer/help-smtpPort_it.html
@@ -1,0 +1,4 @@
+<div>
+  Il numero della porta del server di posta. Lasciare il campo vuoto per
+  utilizzare la porta predefinita per il protocollo.
+</div>

--- a/src/main/resources/hudson/tasks/Mailer/help-smtpServer_it.html
+++ b/src/main/resources/hudson/tasks/Mailer/help-smtpServer_it.html
@@ -1,0 +1,11 @@
+<div>
+  Il nome del server di posta. Lasciare il campo vuoto per utilizzare il
+  server predefinito (normalmente, quello in esecuzione su localhost).
+
+  <p>
+  Jenkins utilizza JavaMail per inviare i messaggi di posta elettronica, e
+  JavaMail consente di specificare impostazioni aggiuntive da fornire come
+  proprietà di sistema al container. Si veda
+  <a href="http://jenkins-ci.org/javamail-properties">questo documento</a> per
+  un elenco dei possibili valori e dei relativi effetti.
+</div>

--- a/src/main/resources/hudson/tasks/Mailer/help-useSsl_it.html
+++ b/src/main/resources/hudson/tasks/Mailer/help-useSsl_it.html
@@ -1,0 +1,10 @@
+<div>
+  Specifica se utilizzare o meno SSL per connettersi al server SMTP. La
+  porta predefinita utilizzata è la 465.
+
+  <p>
+  È possibile configurare altre opzioni avanzate impostando delle proprietà di
+  sistema. Si veda <a href="http://jenkins-ci.org/javamail-properties">
+  questo documento</a> per un elenco dei possibili valori e dei relativi
+  effetti.
+</div>

--- a/src/main/resources/hudson/tasks/Mailer/help_it.html
+++ b/src/main/resources/hudson/tasks/Mailer/help_it.html
@@ -1,0 +1,22 @@
+<div>
+  Se configurato, Jenkins invierà un messaggio di posta elettronica ai
+  destinatari selezionati al verificarsi di un certo evento importante.
+
+  <ol>
+    <li>Ogni compilazione non riuscita scatena un nuovo messaggio di posta
+        elettronica.
+    <li>Una compilazione riuscita che ne segue una non riuscita (o instabile)
+        scatena un nuovo messaggio di posta elettronica che indica che un
+        momento di crisi è terminato.
+    <li>Una compilazione instabile che ne segue una riuscita scatena un nuovo
+        messaggio di posta elettronica che indica che si è verificata una
+        regressione.
+    <li>A meno che non si sia adottata una diversa configurazione, ogni
+        compilazione instabile scatena un nuovo messaggio di posta elettronica
+        che indica che la regressione è ancora presente.
+  </ol>
+
+  Per i progetti in cui le compilazioni instabili sono la norma,
+  deselezionare l'opzione "Invia un messaggio di posta elettronica per ogni
+  compilazione non stabile".
+</div>

--- a/src/main/resources/hudson/tasks/SMTPAuthentication/config_it.properties
+++ b/src/main/resources/hudson/tasks/SMTPAuthentication/config_it.properties
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (C) 2004-2020, Sun Microsystems, Inc., Alessandro Menti
+# Copyright (C) 2020 Alessandro Menti
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-description=L''indirizzo di posta elettronica, ad esempio \
-  <tt>joe.chin@sun.com</tt>
-E-mail\ address=Indirizzo di posta elettronica
+User\ Name=Nome utente
+Password=Password

--- a/src/main/resources/jenkins/plugins/mailer/tasks/i18n/Messages_it.properties
+++ b/src/main/resources/jenkins/plugins/mailer/tasks/i18n/Messages_it.properties
@@ -1,1 +1,59 @@
-MailCommand.ShortDescription=Legge lo standard input e lo invia come messaggio di posta elettronica.
+# The MIT License
+#
+# Copyright (C) 2018 - 2020 Oleg Nenashev, Alessandro Menti
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+MailCommand.ShortDescription=Legge lo standard input e lo invia come \
+  messaggio di posta elettronica.
+Mailer.DisplayName=Notifiche tramite posta elettronica
+Mailer.EmailSentSuccessfully=Il messaggio \ufffd stato inviato con successo
+Mailer.FailedToSendEmail=Errore durante l''invio del messaggio
+Mailer.Suffix.Error=Il valore di questo campo deve essere "@" seguito da un \
+  nome di dominio.
+Mailer.TestMail.Content=Questo \ufffd il messaggio di posta elettronica di \
+  prova numero {0} inviato da {1}
+Mailer.TestMail.Subject=Messaggio di posta elettronica di prova numero {0}
+Mailer.Unknown.Host.Name=Nome host sconosciuto: 
+Mailer.UserProperty.DisplayName=Posta elettronica
+MailSender.BackToNormalMail.Subject=La compilazione Jenkins \ufffd tornata {0}:
+MailSender.BackToNormal.Normal=normale
+MailSender.BackToNormal.Stable=stabile
+MailSender.FailureMail.Changes=Modifiche:
+MailSender.FailureMail.FailedToAccessBuildLog=Errore di accesso al log della \
+  compilazione
+MailSender.FailureMail.Subject=La compilazione Jenkins non \ufffd riuscita:
+MailSender.Link=Si veda <{0}>
+MailSender.ListEmpty=Tentativo di invio di un messaggio di posta elettronica \
+  a un elenco di destinatari vuoto ignorato.
+MailSender.NoAddress=Invio del messaggio di posta elettronica a {0} non \
+  riuscito perch\ufffd non \ufffd noto nessun indirizzo e non \ufffd stato \
+  configurato alcun dominio di posta elettronica predefinito.
+MailSender.unknown_user=Non invio un messaggio all''utente non registrato {0}
+MailSender.UnstableMail.StillUnstable.Subject=La compilazione Jenkins \ufffd \
+  ancora instabile:
+MailSender.UnstableMail.Subject=La compilazione Jenkins \ufffd instabile:
+MailSender.UnstableMail.ToUnStable.Subject=La compilazione Jenkins \ufffd \
+  diventata instabile:
+MailSender.user_without_read=Non invio un messaggio all''utente {0} \
+  perch\ufffd non ha il permesso di visualizzare {1}
+MailSender.warning_unknown_user=Avviso: {0} non \ufffd un utente riconosciuto, \
+  invio comunque il messaggio di posta elettronica
+MailSender.warning_user_without_read=Avviso: l''utente {0} non ha il permesso \
+  di visualizzare {1}, invio comunque il messaggio di posta elettronica


### PR DESCRIPTION
This PR updates the Italian translation of this plugin.

Note that I have redone the translation from scratch; for this reason, the copyright notice in `src/main/resources/hudson/tasks/Mailer/UserProperty/config_it.properties` has been changed to include only my name.