### PR TITLE
Hacktoberfest: Trim white space

### DIFF
--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -26,7 +26,7 @@ package hudson.tasks;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import static hudson.Util.fixEmptyAndTrim;
+import hudson.Util;
 
 import hudson.BulkChange;
 import hudson.EnvVars;
@@ -355,7 +355,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
 
         @DataBoundSetter
         public void setReplyToAddress(String address) {
-            this.replyToAddress = Util.fixEmpty(address);
+            this.replyToAddress = Util.fixEmptyAndTrim(address);
             save();
         }
 
@@ -370,12 +370,14 @@ public class Mailer extends Notifier implements SimpleBuildStep {
             final String SMTP_PORT_PROPERTY = "mail.smtp.port";
             final String SMTP_SOCKETFACTORY_PORT_PROPERTY = "mail.smtp.socketFactory.port";
 
-            smtpPort = fixEmptyAndTrim(smtpPort);
-            smtpAuthUserName = fixEmptyAndTrim(smtpAuthUserName);
+            smtpHost = Util.fixEmptyAndTrim(smtpHost);
+            smtpPort = Util.fixEmptyAndTrim(smtpPort);
+            smtpAuthUserName = Util.fixEmptyAndTrim(smtpAuthUserName);
 
             Properties props = new Properties(System.getProperties());
-            if(fixEmptyAndTrim(smtpHost)!=null)
-                props.put("mail.smtp.host",smtpHost);
+            if(smtpHost!=null) {
+                props.put("mail.smtp.host", smtpHost);
+            }
             if (smtpPort!=null) {
                 props.put(SMTP_PORT_PROPERTY, smtpPort);
             }
@@ -582,7 +584,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
 
         @DataBoundSetter
         public void setSmtpHost(String smtpHost) {
-            this.smtpHost = nullify(smtpHost);
+            this.smtpHost = Util.fixEmptyAndTrim(smtpHost);
             save();
         }
 
@@ -600,7 +602,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
 
         @DataBoundSetter
         public void setSmtpPort(String smtpPort) {
-            this.smtpPort = smtpPort;
+            this.smtpPort = Util.fixEmptyAndTrim(smtpPort);
             save();
         }
 
@@ -609,7 +611,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
             if (charset == null || charset.length() == 0) {
                 charset = "UTF-8";
             }
-            this.charset = charset;
+            this.charset = Util.fixEmptyAndTrim(charset);
             save();
         }
 
@@ -668,7 +670,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
 
         public FormValidation doCheckSmtpServer(@QueryParameter String value) {
             try {
-                if (fixEmptyAndTrim(value)!=null)
+                if (Util.fixEmptyAndTrim(value)!=null)
                     InetAddress.getByName(value);
                 return FormValidation.ok();
             } catch (UnknownHostException e) {
@@ -677,7 +679,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
         }
 
         public FormValidation doCheckDefaultSuffix(@QueryParameter String value) {
-            if (value.matches("@[A-Za-z0-9.\\-]+") || fixEmptyAndTrim(value)==null)
+            if (value.matches("@[A-Za-z0-9.\\-]+") || Util.fixEmptyAndTrim(value)==null)
                 return FormValidation.ok();
             else
                 return FormValidation.error(Messages.Mailer_Suffix_Error());

--- a/src/main/java/hudson/tasks/SMTPAuthentication.java
+++ b/src/main/java/hudson/tasks/SMTPAuthentication.java
@@ -5,6 +5,7 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.Secret;
 import org.kohsuke.stapler.DataBoundConstructor;
+import hudson.Util;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -17,7 +18,7 @@ public class SMTPAuthentication extends AbstractDescribableImpl<SMTPAuthenticati
 
     @DataBoundConstructor
     public SMTPAuthentication(String username, Secret password) {
-        this.username = username;
+        this.username = Util.fixEmptyAndTrim(username);
         this.password = password;
     }
 

--- a/src/main/resources/hudson/tasks/Mailer/global.jelly
+++ b/src/main/resources/hudson/tasks/Mailer/global.jelly
@@ -42,7 +42,7 @@ THE SOFTWARE.
         <f:checkbox />
       </f:entry>
       <f:entry title="${%SMTP Port}" field="smtpPort">
-        <f:textbox />
+        <f:number />
       </f:entry>
       <f:entry title="${%Reply-To Address}" field="replyToAddress">
         <f:textbox />

--- a/src/test/java/hudson/tasks/MailerTest.java
+++ b/src/test/java/hudson/tasks/MailerTest.java
@@ -113,6 +113,86 @@ public class MailerTest {
         return new TestProject(m);
     }
 
+    @Test
+    public void testFixEmptyAndTrimOne() throws Exception {
+        DescriptorImpl d = Mailer.descriptor();
+        d.setSmtpHost("smtp.host");
+        d.setAuthentication(new SMTPAuthentication("user", Secret.fromString("pass")));
+        d.setSmtpPort("1025");
+        d.setReplyToAddress("foo@bar.com");
+        d.setCharset("UTF-8");
+
+        rule.submit(rule.createWebClient().goTo("configure").getFormByName("config"));
+
+        assertEquals("smtp.host",d.getSmtpHost());
+        SMTPAuthentication authentication = d.getAuthentication();
+        assertEquals("user",authentication.getUsername());
+        assertEquals("pass",authentication.getPassword().getPlainText());
+        assertEquals("1025",d.getSmtpPort());
+        assertEquals("foo@bar.com",d.getReplyToAddress());
+        assertEquals("UTF-8",d.getCharset());
+    }
+
+    @Test
+    public void testFixEmptyAndTrimTwo() throws Exception {
+        DescriptorImpl d = Mailer.descriptor();
+        d.setSmtpHost("   smtp.host   ");
+        d.setAuthentication(new SMTPAuthentication("   user   ", Secret.fromString("pass")));
+        d.setSmtpPort("   1025   ");
+        d.setReplyToAddress("   foo@bar.com   ");
+        d.setCharset("   UTF-8   ");
+
+        rule.submit(rule.createWebClient().goTo("configure").getFormByName("config"));
+
+        assertEquals("smtp.host",d.getSmtpHost());
+        SMTPAuthentication authentication = d.getAuthentication();
+        assertEquals("user",authentication.getUsername());
+        assertEquals("pass",authentication.getPassword().getPlainText());
+        assertEquals("1025",d.getSmtpPort());
+        assertEquals("foo@bar.com",d.getReplyToAddress());
+        assertEquals("UTF-8",d.getCharset());
+    }
+
+    @Test
+    public void testFixEmptyAndTrimThree() throws Exception {
+        DescriptorImpl d = Mailer.descriptor();
+        d.setSmtpHost("");
+        d.setAuthentication(new SMTPAuthentication("", Secret.fromString("pass")));
+        d.setSmtpPort("");
+        d.setReplyToAddress("");
+        d.setCharset("");
+
+        rule.submit(rule.createWebClient().goTo("configure").getFormByName("config"));
+
+        assertNull(d.getSmtpHost());
+        SMTPAuthentication authentication = d.getAuthentication();
+        assertNull(authentication.getUsername());
+        assertEquals("pass",authentication.getPassword().getPlainText());
+        assertNull(d.getSmtpPort());
+        assertNull(d.getReplyToAddress());
+        assertEquals("UTF-8",d.getCharset());
+    }
+
+    @Test
+    public void testFixEmptyAndTrimFour() throws Exception {
+        DescriptorImpl d = Mailer.descriptor();
+        d.setSmtpHost(null);
+        d.setAuthentication(new SMTPAuthentication(null, Secret.fromString("pass")));
+        d.setSmtpPort(null);
+        d.setReplyToAddress(null);
+        d.setCharset(null);
+
+        rule.submit(rule.createWebClient().goTo("configure").getFormByName("config"));
+
+        assertNull(d.getSmtpHost());
+        SMTPAuthentication authentication = d.getAuthentication();
+        assertNull(authentication.getUsername());
+        assertEquals("pass",authentication.getPassword().getPlainText());
+        assertNull(d.getSmtpPort());
+        assertNull(d.getReplyToAddress());
+        assertEquals("UTF-8",d.getCharset());
+    }
+
     @Bug(1566)
     @Test
     public void testSenderAddress() throws Exception {


### PR DESCRIPTION
Adding trimming to the following attributes:

* SMTP server (smtpHost)
* User Name (authentication/user)
* SMTP Port (smtpHost)
* Reply-To Address (replyToAddress)
* Charset (charset)

Also standardized the reference to Util.fixEmptyAndTrim

Signed-off-by: Darin Pope <darin@planetpope.com>