### PR TITLE
[terminology] Removing indian word in French email example.

### DIFF
--- a/src/main/resources/hudson/tasks/Mailer/UserProperty/config_fr.properties
+++ b/src/main/resources/hudson/tasks/Mailer/UserProperty/config_fr.properties
@@ -21,4 +21,4 @@
 # THE SOFTWARE.
 
 E-mail\ address=Adresse email
-description=Votre adresse email, au format <tt>grace.hooper@jenkins.com</tt>
+description=Votre adresse email, au format <tt>grace.hopper@jenkins.com</tt>

--- a/src/main/resources/hudson/tasks/Mailer/UserProperty/config_fr.properties
+++ b/src/main/resources/hudson/tasks/Mailer/UserProperty/config_fr.properties
@@ -21,4 +21,4 @@
 # THE SOFTWARE.
 
 E-mail\ address=Adresse email
-description=Votre adresse email, au format <tt>joe.l.indien@sun.com</tt>
+description=Votre adresse email, au format <tt>grace.hooper@jenkins.com</tt>


### PR DESCRIPTION
I saw that when checking the french version of user configuration (for https://github.com/jenkinsci/jenkins/pull/5009). The word "Indian" may be offensive, I am not sure but I prefer to be on fence and use a safe name.

I checked, in english it's not the same name (it's joe chin, no idea if it's ok or not).