### PR TITLE
[JENKINS-64629] Fix uncaught exception for unauthorized users

### DIFF
--- a/src/main/java/hudson/tasks/MailSender.java
+++ b/src/main/java/hudson/tasks/MailSender.java
@@ -35,6 +35,7 @@ import jenkins.plugins.mailer.tasks.MailAddressFilter;
 import jenkins.plugins.mailer.tasks.MimeMessageBuilder;
 import jenkins.plugins.mailer.tasks.i18n.Messages;
 import org.acegisecurity.Authentication;
+import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
@@ -456,6 +457,8 @@ public class MailSender {
     static /* not final */ boolean SEND_TO_USERS_WITHOUT_READ = Boolean.getBoolean(MailSender.class.getName() + ".SEND_TO_USERS_WITHOUT_READ");
     /** If set, send to unknown users. */
     static /* not final */ boolean SEND_TO_UNKNOWN_USERS = Boolean.getBoolean(MailSender.class.getName() + ".SEND_TO_UNKNOWN_USERS");
+    /** If set, send to unauthorized users. Unauthorized users are users where {@link User#impersonate()} fails with a security-related exception. */
+    static /* not final */ boolean SEND_TO_UNAUTHORIZED_USERS = Boolean.getBoolean(MailSender.class.getName() + ".SEND_TO_UNAUTHORIZED_USERS");
 
     @Nonnull
     String getUserEmailList(TaskListener listener, AbstractBuild<?, ?> build) throws AddressException, UnsupportedEncodingException {
@@ -483,6 +486,13 @@ public class MailSender {
                             listener.getLogger().println(Messages.MailSender_warning_unknown_user(adrs));
                         } else {
                             listener.getLogger().println(Messages.MailSender_unknown_user(adrs));
+                            continue;
+                        }
+                    } catch (AuthenticationException e) {
+                        if (SEND_TO_UNAUTHORIZED_USERS) {
+                            listener.getLogger().println(Messages.MailSender_warning_unauthorized_user(adrs));
+                        } else {
+                            listener.getLogger().println(Messages.MailSender_unauthorized_user(adrs));
                             continue;
                         }
                     }

--- a/src/main/java/hudson/tasks/MailSender.java
+++ b/src/main/java/hudson/tasks/MailSender.java
@@ -492,7 +492,7 @@ public class MailSender {
                         if (SEND_TO_UNAUTHORIZED_USERS) {
                             listener.getLogger().println(Messages.MailSender_warning_unauthorized_user(adrs));
                         } else {
-                            listener.getLogger().println(Messages.MailSender_unauthorized_user(adrs));
+                            listener.getLogger().println(Messages.MailSender_unauthorized_user(adrs, e.getMessage()));
                             continue;
                         }
                     }

--- a/src/main/resources/jenkins/plugins/mailer/tasks/i18n/Messages.properties
+++ b/src/main/resources/jenkins/plugins/mailer/tasks/i18n/Messages.properties
@@ -36,7 +36,7 @@ MailSender.user_without_read=Not sending mail to user {0} with no permission to 
 MailSender.warning_user_without_read=Warning: user {0} has no permission to view {1}, but sending mail anyway
 MailSender.unknown_user=Not sending mail to unregistered user {0}
 MailSender.warning_unknown_user=Warning: {0} is not a recognized user, but sending mail anyway
-MailSender.unauthorized_user=Not sending mail to unauthorized user {0}
+MailSender.unauthorized_user=Not sending mail to unauthorized user {0} due to: {1}
 MailSender.warning_unauthorized_user=Warning: {0} is not an authorized user, but sending mail anyway
 
 Mailer.DisplayName=E-mail Notification

--- a/src/main/resources/jenkins/plugins/mailer/tasks/i18n/Messages.properties
+++ b/src/main/resources/jenkins/plugins/mailer/tasks/i18n/Messages.properties
@@ -36,6 +36,8 @@ MailSender.user_without_read=Not sending mail to user {0} with no permission to 
 MailSender.warning_user_without_read=Warning: user {0} has no permission to view {1}, but sending mail anyway
 MailSender.unknown_user=Not sending mail to unregistered user {0}
 MailSender.warning_unknown_user=Warning: {0} is not a recognized user, but sending mail anyway
+MailSender.unauthorized_user=Not sending mail to unauthorized user {0}
+MailSender.warning_unauthorized_user=Warning: {0} is not an authorized user, but sending mail anyway
 
 Mailer.DisplayName=E-mail Notification
 Mailer.Unknown.Host.Name=Unknown host name: 


### PR DESCRIPTION
When attempting to email a user with a locked, disabled, or otherwise unauthorized account, different types of AuthenticationException were not caught which would cause the mail to fail.

https://issues.jenkins.io/browse/JENKINS-64629

Related to error message updates in https://github.com/jenkinsci/ldap-plugin/pull/74 which helped surface the problem.

@jeffret-b @basil @jglick @l3ender