### PR TITLE
Drop dependency on Commons Codec

### DIFF
--- a/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
+++ b/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
@@ -25,7 +25,6 @@
 package jenkins.plugins.mailer.tasks;
 
 import hudson.model.TaskListener;
-import hudson.remoting.Base64;
 import hudson.tasks.Mailer;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
@@ -49,6 +48,7 @@ import javax.mail.internet.MimeUtility;
 
 import java.io.UnsupportedEncodingException;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedHashSet;
@@ -220,7 +220,7 @@ public class MimeMessageBuilder {
             String encodedIdentity;
             try {
                 RSAPublicKey publicKey = InstanceIdentity.get().getPublic();
-                encodedIdentity = Base64.encode(publicKey.getEncoded());
+                encodedIdentity = Base64.getEncoder().encodeToString(publicKey.getEncoded());
             } catch (Throwable t) {
                 // Ignore. Just don't add the identity header.
                  logError("Failed to set Jenkins Identity header on email.", t);

--- a/src/test/java/jenkins/plugins/mailer/tasks/MimeMessageBuilderTest.java
+++ b/src/test/java/jenkins/plugins/mailer/tasks/MimeMessageBuilderTest.java
@@ -26,7 +26,6 @@ package jenkins.plugins.mailer.tasks;
 import hudson.tasks.Mailer;
 import jenkins.model.JenkinsLocationConfiguration;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,6 +45,7 @@ import java.io.StringWriter;
 import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
@@ -95,7 +95,7 @@ public class MimeMessageBuilderTest {
 
         // Make sure we can regen the instance identifier public key
         String encodedIdent = mimeMessage.getHeader("X-Instance-Identity")[0];
-        byte[] image = Base64.decodeBase64(encodedIdent);
+        byte[] image = Base64.getDecoder().decode(encodedIdent);
         PublicKey publicKey = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(image));
         Assert.assertNotNull(publicKey);
     }


### PR DESCRIPTION
Java 8 includes a built-in Base64 decoder, so there is no reason to depend on a third-party library. Using the built-in Java Platform functionality simplifies maintenance.

CC @alecharp