### PR TITLE
Update deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
           <groupId>org.hamcrest</groupId>
           <artifactId>hamcrest-core</artifactId>
         </exclusion>
-        <exclusion> <!-- TODO unwanted dep via plugin-util-api -->
+        <exclusion> <!-- TODO pending https://github.com/jenkinsci/plugin-util-api-plugin/releases/tag/v2.9.0 in bom -->
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
         </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
           <groupId>org.hamcrest</groupId>
           <artifactId>hamcrest-core</artifactId>
         </exclusion>
+        <exclusion> <!-- TODO unwanted dep via plugin-util-api -->
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -94,6 +98,12 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion> <!-- Not even sure how this was possible to begin with? -->
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>mailer</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,15 +25,15 @@
     <revision>1.35</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <jenkins.version>2.235.5</jenkins.version>
+    <jenkins.version>2.289.1</jenkins.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.235.x</artifactId>
-        <version>918.vae501d2cdc99</version>
+        <artifactId>bom-2.289.x</artifactId>
+        <version>1075.v14bef33e5d7b</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -57,15 +57,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
-      <version>1.4.7</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>2.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -157,7 +150,4 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-  <build>
-    <defaultGoal>clean hpi:run</defaultGoal>
-  </build>
 </project>

--- a/src/main/java/hudson/tasks/MailSender.java
+++ b/src/main/java/hudson/tasks/MailSender.java
@@ -39,8 +39,8 @@ import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.mail.Address;
 import javax.mail.MessagingException;
 import javax.mail.Transport;
@@ -460,7 +460,7 @@ public class MailSender {
     /** If set, send to unauthorized users. Unauthorized users are users where {@link User#impersonate()} fails with a security-related exception. */
     static /* not final */ boolean SEND_TO_UNAUTHORIZED_USERS = Boolean.getBoolean(MailSender.class.getName() + ".SEND_TO_UNAUTHORIZED_USERS");
 
-    @Nonnull
+    @NonNull
     String getUserEmailList(TaskListener listener, AbstractBuild<?, ?> build) throws AddressException, UnsupportedEncodingException {
         Set<User> users = build.getCulprits();
         StringBuilder userEmails = new StringBuilder();

--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -24,6 +24,7 @@
  */
 package hudson.tasks;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Util;
@@ -62,8 +63,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import javax.mail.Address;
 import javax.mail.Authenticator;
 import javax.mail.Message;
@@ -215,8 +214,8 @@ public class Mailer extends Notifier implements SimpleBuildStep {
      * @throws UnsupportedEncodingException Unsupported encoding
      * @since TODO
      */
-    public static @Nonnull InternetAddress stringToAddress(@Nonnull String strAddress, 
-            @Nonnull String charset) throws AddressException, UnsupportedEncodingException {
+    public static @NonNull InternetAddress stringToAddress(@NonNull String strAddress, 
+            @NonNull String charset) throws AddressException, UnsupportedEncodingException {
         Matcher m = ADDRESS_PATTERN.matcher(strAddress);
         if(!m.matches()) {
             return new InternetAddress(strAddress);

--- a/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
+++ b/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
@@ -33,7 +33,7 @@ import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.mail.Address;
 import javax.mail.BodyPart;
 import javax.mail.Message;
@@ -94,12 +94,12 @@ public class MimeMessageBuilder {
         }
     }
 
-    public MimeMessageBuilder setCharset(@Nonnull String charset) {
+    public MimeMessageBuilder setCharset(@NonNull String charset) {
         this.charset = charset;
         return this;
     }
 
-    public MimeMessageBuilder setMimeType(@Nonnull String mimeType) {
+    public MimeMessageBuilder setMimeType(@NonNull String mimeType) {
         this.mimeType = mimeType;
         return this;
     }
@@ -109,17 +109,17 @@ public class MimeMessageBuilder {
         return this;
     }
 
-    public MimeMessageBuilder setDefaultSuffix(@Nonnull String defaultSuffix) {
+    public MimeMessageBuilder setDefaultSuffix(@NonNull String defaultSuffix) {
         this.defaultSuffix = defaultSuffix;
         return this;
     }
 
-    public MimeMessageBuilder setFrom(@Nonnull String from) {
+    public MimeMessageBuilder setFrom(@NonNull String from) {
         this.from = from;
         return this;
     }
 
-    public MimeMessageBuilder setReplyTo(@Nonnull String replyTo) {
+    public MimeMessageBuilder setReplyTo(@NonNull String replyTo) {
         try {
             final List<InternetAddress> addresses = toNormalizedAddresses(replyTo);
             // Done after to leave the current value untouched if there is a parsing error.
@@ -131,7 +131,7 @@ public class MimeMessageBuilder {
         return this;
     }
 
-    public MimeMessageBuilder addReplyTo(@Nonnull String replyTo) {
+    public MimeMessageBuilder addReplyTo(@NonNull String replyTo) {
         try {
             this.replyTo.addAll(toNormalizedAddresses(replyTo));
         } catch(UnsupportedEncodingException e) {
@@ -141,12 +141,12 @@ public class MimeMessageBuilder {
     }
 
 
-    public MimeMessageBuilder setSubject(@Nonnull String subject) {
+    public MimeMessageBuilder setSubject(@NonNull String subject) {
         this.subject = subject;
         return this;
     }
 
-    public MimeMessageBuilder setBody(@Nonnull String body) {
+    public MimeMessageBuilder setBody(@NonNull String body) {
         this.body = body;
         return this;
     }
@@ -156,7 +156,7 @@ public class MimeMessageBuilder {
         return this;
     }
 
-    public MimeMessageBuilder addRecipients(@Nonnull String recipients) throws UnsupportedEncodingException {
+    public MimeMessageBuilder addRecipients(@NonNull String recipients) throws UnsupportedEncodingException {
         addRecipients(recipients, Message.RecipientType.TO);
         return this;
     }
@@ -168,7 +168,7 @@ public class MimeMessageBuilder {
      * @return the constructed message with the given recipients
      * @throws UnsupportedEncodingException in case of encoding problems
      */
-    public MimeMessageBuilder addRecipients(@Nonnull String recipients, @Nonnull Message.RecipientType recipientType) throws UnsupportedEncodingException {
+    public MimeMessageBuilder addRecipients(@NonNull String recipients, @NonNull Message.RecipientType recipientType) throws UnsupportedEncodingException {
         StringTokenizer tokens = new StringTokenizer(recipients, " \t\n\r\f,");
         while (tokens.hasMoreTokens()) {
             String addressToken = tokens.nextToken();
@@ -239,7 +239,7 @@ public class MimeMessageBuilder {
         return addresses;
     }
 
-    public static void setInReplyTo(@Nonnull MimeMessage msg, @Nonnull String inReplyTo) throws MessagingException {
+    public static void setInReplyTo(@NonNull MimeMessage msg, @NonNull String inReplyTo) throws MessagingException {
         msg.setHeader("In-Reply-To", inReplyTo);
         msg.setHeader("References", inReplyTo);
     }


### PR DESCRIPTION
Via https://github.com/jenkinsci/mock-load-builder-plugin/pull/20 I found that this plugin was not yet adapted to https://github.com/jenkinsci/jenkins/pull/4660.

Unlike https://github.com/jenkinsci/jackson2-api-plugin/pull/96 we were not bundling the old JavaMail lib, we were just compiling against it.