### PR TITLE
Get JavaMail from core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
-      <version>1.4.7</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
       <version>2.2</version>
@@ -74,6 +68,10 @@
       <version>1.9</version>
       <scope>test</scope>
       <exclusions>
+        <exclusion>
+          <groupId>javax.mail</groupId>
+          <artifactId>mail</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>


### PR DESCRIPTION
Noticed in mock-load-builder-plugin#20. The explicit dependency on JavaMail causes Enforcer errors for other plugins with this plugin in their dependency chain and is unnecessary because the plugin parent POM already adds a dependency on core which ships this library anyway.