### PR TITLE
Use detached JavaMail plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-weekly</artifactId>
-        <version>1090.v0a_33df40457a_</version>
+        <version>1117.v62a_f6a_01de98</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.329-rc31978.fa_f50a_a_d3e46</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/6165 -->
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -31,8 +31,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.289.x</artifactId>
-        <version>1075.v14bef33e5d7b</version>
+        <artifactId>bom-weekly</artifactId>
+        <version>1090.v0a_33df40457a_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -52,10 +52,6 @@
         <exclusion>
           <groupId>org.hamcrest</groupId>
           <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-        <exclusion> <!-- TODO pending https://github.com/jenkinsci/plugin-util-api-plugin/releases/tag/v2.9.0 in bom -->
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -79,7 +75,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>javax-mail-api</artifactId>
-      <version>1.6.2-2</version>
+      <version>1.6.2-5</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </licenses>
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.332.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -30,8 +30,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-weekly</artifactId>
-        <version>1117.v62a_f6a_01de98</version>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1155.v77b_fd92a_26fc</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -74,7 +74,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>javax-mail-api</artifactId>
-      <version>1.6.2-5</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <java.level>8</java.level>
-    <jenkins.version>2.329-rc31978.fa_f50a_a_d3e46</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/6165 -->
+    <jenkins.version>2.331</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 

--- a/src/test/java/hudson/tasks/MailerTest.java
+++ b/src/test/java/hudson/tasks/MailerTest.java
@@ -62,6 +62,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Optional;
@@ -297,7 +298,11 @@ public class MailerTest {
 
         @Override
         public synchronized void load() {
-            getConfigFile().delete();
+            try {
+                getConfigFile().delete();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
             super.load();
         }
     };

--- a/src/test/java/hudson/tasks/MailerTest.java
+++ b/src/test/java/hudson/tasks/MailerTest.java
@@ -60,6 +60,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;


### PR DESCRIPTION
Downstream of #142 and jenkinsci/jenkins#6165. Bumps the baseline to one containing jenkinsci/jenkins#6165, thus using the detached JavaMail plugin, but does not upgrade to Jakarta Mail.