### PR TITLE
use a versionthat works give prior releases

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
--Dchangelist.format=%d.v%s
+-Dchangelist.format=%d-v%s


### PR DESCRIPTION
`400.v12312312` is older than `1.1` in Maven but not jenkins.  this confuses tools that use maven for version comparison, most likely dependabot et al).

@jglick @Pldi23

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
