### PR TITLE
Require 2.357+, use `instance-identity` as a plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(configurations: [
-  [ platform: "linux", jdk: "8", jenkins: null ],
-  [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "11", jenkins: null ]
+  [platform: "linux", jdk: 11],
+  [platform: "windows", jdk: 11]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </licenses>
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.332.1</jenkins.version>
+    <jenkins.version>2.357</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <useBeta>true</useBeta>
   </properties>
@@ -31,8 +31,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
-        <version>1155.v77b_fd92a_26fc</version>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1461.vb_3c6de28f2b_a_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <scope>provided</scope>
+      <version>116.vf8f487400980</version>
     </dependency>
     <!--
       This must come before jakarta-mail-api in the class path in order to avoid eclipse-ee4j/mail#350.


### PR DESCRIPTION
Picking up https://github.com/jenkinsci/jenkins/pull/6585. See https://github.com/jenkinsci/bom/issues/895#issuecomment-1189030074.
