### PR TITLE
Warn when using insecure auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </licenses>
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.440.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <useBeta>true</useBeta>
   </properties>
@@ -32,22 +32,10 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.440.x</artifactId>
+        <version>2884.vc36b_64ce114a_</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <!-- TODO Remove once in BOM -->
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>jakarta-activation-api</artifactId>
-        <version>2.1.3-1</version>
-      </dependency>
-      <!-- TODO Remove once in BOM -->
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>jakarta-mail-api</artifactId>
-        <version>2.1.3-1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/resources/jenkins/plugins/mailer/tasks/i18n/Messages.properties
+++ b/src/main/resources/jenkins/plugins/mailer/tasks/i18n/Messages.properties
@@ -47,6 +47,8 @@ Mailer.EmailSentSuccessfully=Email was successfully sent
 Mailer.FailedToSendEmail=Failed to send out e-mail
 Mailer.TestMail.Subject=Test email #{0}
 Mailer.TestMail.Content=This is test email #{0} sent from {1}
+Mailer.InsecureAuthWarning=For security when using authentication it is recommended to enable either TLS or SSL
+Mailer.InsecureAuthError=Authentication requires either TLS or SSL to be enabled
 
 MailCommand.ShortDescription=\
  Reads stdin and sends that out as an e-mail.


### PR DESCRIPTION
Additionally if running in FIPS use an error in the form validation and do not support auth without SSL or TLS.

This is handled when we attempt to send as the config is part of the global configuration and could leave the config in an non determinate state

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
