### PR TITLE
Replacing magic numbers with constant

### DIFF
--- a/src/main/java/hudson/tasks/SMTPAuthentication.java
+++ b/src/main/java/hudson/tasks/SMTPAuthentication.java
@@ -17,7 +17,7 @@ import java.io.ObjectStreamException;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class SMTPAuthentication extends AbstractDescribableImpl<SMTPAuthentication> {
-
+    private static final int MIN_PASSWORD_LENGTH = 14;
     private String username;
 
     private Secret password;
@@ -26,7 +26,7 @@ public class SMTPAuthentication extends AbstractDescribableImpl<SMTPAuthenticati
     public SMTPAuthentication(String username, Secret password) {
         this.username = Util.fixEmptyAndTrim(username);
         this.password = password;
-        if (FIPS140.useCompliantAlgorithms() && Secret.toString(password).length() < 14) {
+        if (FIPS140.useCompliantAlgorithms() && Secret.toString(password).length() < MIN_PASSWORD_LENGTH) {
             throw new IllegalArgumentException(jenkins.plugins.mailer.tasks.i18n.Messages.Mailer_SmtpPassNotFipsCompliant());
         }
     }
@@ -40,7 +40,7 @@ public class SMTPAuthentication extends AbstractDescribableImpl<SMTPAuthenticati
     }
 
     private Object readResolve() throws ObjectStreamException {
-        if (FIPS140.useCompliantAlgorithms() && Secret.toString(password).length() < 14) {
+        if (FIPS140.useCompliantAlgorithms() && Secret.toString(password).length() < MIN_PASSWORD_LENGTH) {
             throw new IllegalStateException("Mailer SMTP password: " + jenkins.plugins.mailer.tasks.i18n.Messages.Mailer_SmtpPassNotFipsCompliant());
         }
         return this;
@@ -56,7 +56,7 @@ public class SMTPAuthentication extends AbstractDescribableImpl<SMTPAuthenticati
 
         @RequirePOST
         public FormValidation doCheckPassword(@QueryParameter Secret password) {
-            if (FIPS140.useCompliantAlgorithms() && Secret.toString(password).length() < 14) {
+            if (FIPS140.useCompliantAlgorithms() && Secret.toString(password).length() < MIN_PASSWORD_LENGTH) {
                 return FormValidation.error(jenkins.plugins.mailer.tasks.i18n.Messages.Mailer_SmtpPassNotFipsCompliant());
             }
             return FormValidation.ok();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
### Notes
While I was reading though code notice some magic numbers on FIPS password length, nothing really stopping FIPS standards to change password length in future to increase security posture. This will require several modifications in code which is error prone. Replacing magic numbers with `MIN_PASSWORD_LENGTH` constant.

### Testing done
Done testing with `mvn clean insatll`

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
Running tests for org.jenkins-ci.plugins:mailer:999999-SNAPSHOT
[INFO] Running hudson.tasks.MailAddressResolverTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.094 s -- in hudson.tasks.MailAddressResolverTest
[INFO] Running hudson.tasks.MailSenderTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.247 s -- in hudson.tasks.MailSenderTest
[INFO] Running hudson.tasks.MailerTest
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 133.7 s -- in hudson.tasks.MailerTest
[INFO] Running jenkins.plugins.mailer.FipsModeTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.00 s -- in jenkins.plugins.mailer.FipsModeTest
[INFO] Running jenkins.plugins.mailer.MailerJCasCCompatibilityTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.165 s -- in jenkins.plugins.mailer.MailerJCasCCompatibilityTest
[INFO] Running jenkins.plugins.mailer.tasks.MailAddressFilterTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.073 s -- in jenkins.plugins.mailer.tasks.MailAddressFilterTest
[INFO] Running jenkins.plugins.mailer.tasks.MimeMessageBuilderTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.101 s -- in jenkins.plugins.mailer.tasks.MimeMessageBuilderTest
[INFO] Running org.jenkins_ci.plugins.mailer.InjectedTest
[INFO] Tests run: 80, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.083 s -- in org.jenkins_ci.plugins.mailer.InjectedTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 120, Failures: 0, Errors: 0, Skipped: 0

```

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [N/A] Link to relevant issues in GitHub or Jira
- [N/A] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
