### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/src/test/java/hudson/tasks/MailAddressResolverTest.java
+++ b/src/test/java/hudson/tasks/MailAddressResolverTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2012-2013 Kohsuke Kawaguchi, Red Hat, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,39 +23,39 @@
  */
 package hudson.tasks;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import hudson.ExtensionList;
+import hudson.model.Hudson;
+import hudson.model.User;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Bug;
+import org.mockito.MockedStatic;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import hudson.ExtensionList;
-import hudson.model.Hudson;
-import hudson.model.User;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-
-import jenkins.model.Jenkins;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.jvnet.hudson.test.Bug;
-import org.mockito.MockedStatic;
 
 /**
  * @author Kohsuke Kawaguchi, ogondza
  */
-public class MailAddressResolverTest {
+class MailAddressResolverTest {
 
     private User user;
     private Jenkins jenkins;
     private Mailer.DescriptorImpl descriptor;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
 
         jenkins = mock(Hudson.class);
 
@@ -67,7 +67,7 @@ public class MailAddressResolverTest {
     }
 
     @Test
-    public void nameAlreadyIsAnAddress() throws Exception {
+    void nameAlreadyIsAnAddress() throws Exception {
 
       try (MockedStatic<Mailer> mockedMailer = mockStatic(Mailer.class)) {
         mockedMailer.when(Mailer::descriptor).thenReturn(descriptor);
@@ -76,7 +76,7 @@ public class MailAddressResolverTest {
     }
 
     @Test
-    public void nameContainsAddress() throws Exception {
+    void nameContainsAddress() throws Exception {
 
       try (MockedStatic<Mailer> mockedMailer = mockStatic(Mailer.class)) {
         mockedMailer.when(Mailer::descriptor).thenReturn(descriptor);
@@ -86,7 +86,7 @@ public class MailAddressResolverTest {
 
     @Bug(5164)
     @Test
-    public void test5164() throws Exception {
+    void test5164() throws Exception {
 
       try (MockedStatic<Mailer> mockedMailer = mockStatic(Mailer.class)) {
         mockedMailer.when(Mailer::descriptor).thenReturn(descriptor);
@@ -116,7 +116,7 @@ public class MailAddressResolverTest {
     }
 
     @Test
-    public void doNotResolveWhenUsingFastResolution() throws Exception {
+    void doNotResolveWhenUsingFastResolution() throws Exception {
       try (MockedStatic<Mailer> mockedMailer = mockStatic(Mailer.class);
            MockedStatic<ExtensionList> mockedExtensionList = mockStatic(ExtensionList.class)) {
         mockedMailer.when(Mailer::descriptor).thenReturn(descriptor);
@@ -134,7 +134,7 @@ public class MailAddressResolverTest {
     }
 
     @Test
-    public void doResolveWhenNotUsingFastResolution() throws Exception {
+    void doResolveWhenNotUsingFastResolution() throws Exception {
 
       try (MockedStatic<ExtensionList> mockedExtensionList = mockStatic(ExtensionList.class)) {
         final MailAddressResolver resolver = mockResolver();
@@ -151,16 +151,16 @@ public class MailAddressResolverTest {
     }
 
     @Test
-    public void doResolveWhenUsingExplicitlUserEmail() {
+    void doResolveWhenUsingExplicitlUserEmail() {
         final String testEmail = "very_strange_email@test.case";
-        
+
         when(user.getProperty(Mailer.UserProperty.class)).thenReturn(
             new Mailer.UserProperty(testEmail));
-        
+
         final String address = MailAddressResolver.resolveFast(user);
         assertEquals(testEmail, address);
     }
-    
+
     private MailAddressResolver mockResolver() {
 
         return mock(MailAddressResolver.class);

--- a/src/test/java/hudson/tasks/MailSenderTest.java
+++ b/src/test/java/hudson/tasks/MailSenderTest.java
@@ -9,38 +9,40 @@ import hudson.model.TaskListener;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.util.StreamTaskListener;
+import jenkins.model.Jenkins;
+import jenkins.plugins.mailer.tasks.i18n.Messages;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.mockito.MockedStatic;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import jenkins.model.Jenkins;
-import jenkins.plugins.mailer.tasks.i18n.Messages;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-import org.mockito.MockedStatic;
 
 /**
  * Test case for the {@link MailSender}
- * 
+ *
  * See also {@link MailerTest} for more tests for the mailer.
- * 
+ *
  * @author Christoph Kutzinski
  */
 @SuppressWarnings("rawtypes")
-public class MailSenderTest {
-    
+class MailSenderTest {
+
     /**
      * Tests that all culprits from the previous builds upstream build (exclusive)
      * until the current builds upstream build (inclusive) are contained in the recipients
@@ -48,7 +50,7 @@ public class MailSenderTest {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testIncludeUpstreamCulprits() throws Exception {
+    void testIncludeUpstreamCulprits() throws Exception {
       final Jenkins jenkins = mock(Jenkins.class);
       when(jenkins.isUseSecurity()).thenReturn(false);
       try (MockedStatic<Jenkins> mockedJenkins = mockStatic(Jenkins.class)) {
@@ -111,19 +113,19 @@ public class MailSenderTest {
         assertTrue(emailList.contains("this.one.must.be.included.too@example.com"));
       }
     }
-    
+
     /**
      * Creates a previous/next relationship between the builds in the given order.
      */
     private static void createPreviousNextRelationShip(AbstractBuild... builds) {
         int max = builds.length - 1;
-        
+
         for (int i = 0; i < builds.length; i++) {
             if (i < max) {
                 when(builds[i].getNextBuild()).thenReturn(builds[i+1]);
             }
         }
-        
+
         for (int i = builds.length - 1; i >= 0; i--) {
             if (i >= 1) {
                 when(builds[i].getPreviousBuild()).thenReturn(builds[i-1]);
@@ -132,7 +134,8 @@ public class MailSenderTest {
     }
 
     @Issue("SECURITY-372")
-    @Test public void forbiddenMail() throws Exception {
+    @Test
+    void forbiddenMail() throws Exception {
       final Jenkins jenkins = mock(Jenkins.class);
       when(jenkins.isUseSecurity()).thenReturn(true);
       try (MockedStatic<Jenkins> mockedJenkins = mockStatic(Jenkins.class)) {

--- a/src/test/java/jenkins/plugins/mailer/FipsModeTest.java
+++ b/src/test/java/jenkins/plugins/mailer/FipsModeTest.java
@@ -14,9 +14,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RealJenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
-import org.xml.sax.SAXException;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.net.URL;
 

--- a/src/test/java/jenkins/plugins/mailer/MailerJCasCCompatibilityTest.java
+++ b/src/test/java/jenkins/plugins/mailer/MailerJCasCCompatibilityTest.java
@@ -1,28 +1,29 @@
 package jenkins.plugins.mailer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import org.jvnet.hudson.test.RestartableJenkinsRule;
-
 import hudson.tasks.Mailer;
-import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import io.jenkins.plugins.casc.misc.junit.jupiter.AbstractRoundTripTest;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class MailerJCasCCompatibilityTest extends RoundTripAbstractTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@WithJenkins
+class MailerJCasCCompatibilityTest extends AbstractRoundTripTest {
 
     @Override
-    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+    protected void assertConfiguredAsExpected(JenkinsRule jenkinsRule, String s) {
         Mailer.DescriptorImpl descriptor = Mailer.descriptor();
-        assertNotNull("Mailer can not be found", descriptor);
-        assertEquals(String.format("Wrong authentication. Username expected %s but received %s", "fakeuser", descriptor.getAuthentication().getUsername()), "fakeuser", descriptor.getAuthentication().getUsername());
-        assertEquals(String.format("Wrong charset. Expected %s but received %s", "UTF-8", descriptor.getCharset()), "UTF-8", descriptor.getCharset());
-        assertEquals(String.format("Wrong default suffix. Expected %s but received %s", "@mydomain.com", descriptor.getDefaultSuffix()), "@mydomain.com", descriptor.getDefaultSuffix());
-        assertEquals(String.format("Wrong ReplayTo address. Expected %s but received %s", "noreplay@mydomain.com", descriptor.getReplyToAddress()), "noreplay@mydomain.com", descriptor.getReplyToAddress());
-        assertEquals(String.format("Wrong SMTP host. Expected %s but received %s", "smtp.acme.com", descriptor.getSmtpHost()), "smtp.acme.com", descriptor.getSmtpHost());
-        assertEquals(String.format("Wrong SMTP port. Expected %s but received %s", "808080", descriptor.getSmtpPort()), "808080", descriptor.getSmtpPort());
-        assertTrue("SSL should be used", descriptor.getUseSsl());
-        assertTrue("TLS should be used", descriptor.getUseTls());
+        assertNotNull(descriptor, "Mailer can not be found");
+        assertEquals("fakeuser", descriptor.getAuthentication().getUsername(), String.format("Wrong authentication. Username expected %s but received %s", "fakeuser", descriptor.getAuthentication().getUsername()));
+        assertEquals("UTF-8", descriptor.getCharset(), String.format("Wrong charset. Expected %s but received %s", "UTF-8", descriptor.getCharset()));
+        assertEquals("@mydomain.com", descriptor.getDefaultSuffix(), String.format("Wrong default suffix. Expected %s but received %s", "@mydomain.com", descriptor.getDefaultSuffix()));
+        assertEquals("noreplay@mydomain.com", descriptor.getReplyToAddress(), String.format("Wrong ReplayTo address. Expected %s but received %s", "noreplay@mydomain.com", descriptor.getReplyToAddress()));
+        assertEquals("smtp.acme.com", descriptor.getSmtpHost(), String.format("Wrong SMTP host. Expected %s but received %s", "smtp.acme.com", descriptor.getSmtpHost()));
+        assertEquals("808080", descriptor.getSmtpPort(), String.format("Wrong SMTP port. Expected %s but received %s", "808080", descriptor.getSmtpPort()));
+        assertTrue(descriptor.getUseSsl(), "SSL should be used");
+        assertTrue(descriptor.getUseTls(), "TLS should be used");
     }
 
     @Override

--- a/src/test/java/jenkins/plugins/mailer/tasks/MailAddressFilterTest.java
+++ b/src/test/java/jenkins/plugins/mailer/tasks/MailAddressFilterTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2012-2013 Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,9 +24,16 @@
 package jenkins.plugins.mailer.tasks;
 
 import hudson.ExtensionList;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
 import hudson.model.Hudson;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,28 +42,21 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import jakarta.mail.internet.AddressException;
-import jakarta.mail.internet.InternetAddress;
-
-import jenkins.model.Jenkins;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Mudiaga Obada
  */
-public class MailAddressFilterTest {
+class MailAddressFilterTest {
 
     private Hudson jenkins;
     private AbstractBuild<?, ?> build;
     private BuildListener listener;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
 
         jenkins = Mockito.mock(Hudson.class);
         build = Mockito.mock(AbstractBuild.class);
@@ -66,7 +66,7 @@ public class MailAddressFilterTest {
 
     // Without any extension, filter should return identical set
     @Test
-    public void testIdentity() throws Exception {
+    void testIdentity() throws Exception {
 
       try (MockedStatic<Jenkins> mocked = Mockito.mockStatic(Jenkins.class)) {
         mocked.when(Jenkins::get).thenReturn(jenkins);
@@ -77,9 +77,9 @@ public class MailAddressFilterTest {
 
         Set<InternetAddress> filtered = MailAddressFilter.filterRecipients(build, listener, rcp);
 
-        Assert.assertEquals(rcp.size(), filtered.size());
+        assertEquals(rcp.size(), filtered.size());
         for (InternetAddress a : rcp) {
-            Assert.assertTrue(filtered.contains(a));
+            assertTrue(filtered.contains(a));
         }
       }
 
@@ -87,7 +87,7 @@ public class MailAddressFilterTest {
 
     // With an extension, MailAddressFilter must exclude what extension filters
     @Test
-    public void testFilterExtension() throws Exception {
+    void testFilterExtension() throws Exception {
 
       try (MockedStatic<Jenkins> mocked = Mockito.mockStatic(Jenkins.class)) {
         mocked.when(Jenkins::get).thenReturn(jenkins);
@@ -104,9 +104,9 @@ public class MailAddressFilterTest {
 
         Set<InternetAddress> filtered = MailAddressFilter.filterRecipients(build, listener, rcp);
 
-        Assert.assertEquals(rcp.size() - 1, filtered.size());
+        assertEquals(rcp.size() - 1, filtered.size());
 
-        Assert.assertTrue(!filtered.contains(filteredAddress));
+        assertFalse(filtered.contains(filteredAddress));
       }
 
     }

--- a/src/test/java/jenkins/plugins/mailer/tasks/MimeMessageBuilderTest.java
+++ b/src/test/java/jenkins/plugins/mailer/tasks/MimeMessageBuilderTest.java
@@ -24,22 +24,19 @@
 package jenkins.plugins.mailer.tasks;
 
 import hudson.tasks.Mailer;
-import jenkins.model.JenkinsLocationConfiguration;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.mock_javamail.Mailbox;
-import org.kohsuke.stapler.framework.io.WriterOutputStream;
-
 import jakarta.mail.Address;
 import jakarta.mail.Message;
 import jakarta.mail.Transport;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
+import jenkins.model.JenkinsLocationConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.jvnet.mock_javamail.Mailbox;
+import org.kohsuke.stapler.framework.io.WriterOutputStream;
 
 import java.io.StringWriter;
 import java.security.KeyFactory;
@@ -47,10 +44,14 @@ import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-public class MimeMessageBuilderTest {
+@WithJenkins
+class MimeMessageBuilderTest {
     /** Address constant A. */
     private static final String A = "tom.aaaa@gmail.com";
     /** Address constant X. */
@@ -60,17 +61,14 @@ public class MimeMessageBuilderTest {
     /** Address constant Z. */
     private static final String Z = "tom.zzzz@gmail.com";
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
-
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup(JenkinsRule rule) {
         JenkinsLocationConfiguration.get().setAdminAddress(A);
         Mailer.descriptor().setReplyToAddress(A);
     }
 
     @Test
-    public void test_construction() throws Exception {
+    void test_construction() throws Exception {
         MimeMessageBuilder messageBuilder = new MimeMessageBuilder();
 
         messageBuilder.addRecipients("tom.xxxx@gmail.com, tom.yyyy@gmail.com");
@@ -78,67 +76,67 @@ public class MimeMessageBuilderTest {
 
         // check from and reply-to
         Address[] from = mimeMessage.getFrom();
-        Assert.assertNotNull(from);
-        Assert.assertEquals(1, from.length);
-        Assert.assertEquals(A, from[0].toString());
+        assertNotNull(from);
+        assertEquals(1, from.length);
+        assertEquals(A, from[0].toString());
         Address[] replyTo = mimeMessage.getReplyTo();
-        Assert.assertNotNull(from);
-        Assert.assertEquals(1, replyTo.length);
-        Assert.assertEquals(A, replyTo[0].toString());
+        assertNotNull(from);
+        assertEquals(1, replyTo.length);
+        assertEquals(A, replyTo[0].toString());
 
         // check the recipient list...
         Address[] allRecipients = mimeMessage.getAllRecipients();
-        Assert.assertNotNull(allRecipients);
-        Assert.assertEquals(2, allRecipients.length);
-        Assert.assertEquals(X, allRecipients[0].toString());
-        Assert.assertEquals(Y, allRecipients[1].toString());
+        assertNotNull(allRecipients);
+        assertEquals(2, allRecipients.length);
+        assertEquals(X, allRecipients[0].toString());
+        assertEquals(Y, allRecipients[1].toString());
 
         // Make sure we can regen the instance identifier public key
         String encodedIdent = mimeMessage.getHeader("X-Instance-Identity")[0];
         byte[] image = Base64.getDecoder().decode(encodedIdent);
         PublicKey publicKey = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(image));
-        Assert.assertNotNull(publicKey);
+        assertNotNull(publicKey);
     }
 
     @Test
     @Issue("JENKINS-26758")
-    public void test_charset_utf8() throws Exception {
+    void test_charset_utf8() throws Exception {
         MimeMessageBuilder messageBuilder = new MimeMessageBuilder();
         messageBuilder.setMimeType("text/html");
         messageBuilder.setBody("Synthèse");
-  
+
         MimeMessage message = messageBuilder.buildMimeMessage();
         message.saveChanges();
 
         StringWriter sw = new StringWriter();
         ((MimeMultipart)message.getContent()).getBodyPart(0).writeTo(new WriterOutputStream(sw));
-        Assert.assertEquals("Content-Type: text/html; charset=UTF-8\n"
+        assertEquals("Content-Type: text/html; charset=UTF-8\n"
                 + "Content-Transfer-Encoding: quoted-printable\n\n"
-                + "Synth=C3=A8se", 
+                + "Synth=C3=A8se",
                 sw.toString().replaceAll("\r\n?", "\n"));
     }
 
     @Test
     @Issue("JENKINS-26758")
-    public void test_charset_iso_8859_1() throws Exception {
+    void test_charset_iso_8859_1() throws Exception {
         MimeMessageBuilder messageBuilder = new MimeMessageBuilder();
         messageBuilder.setMimeType("text/html");
         messageBuilder.setCharset("ISO-8859-1");
         messageBuilder.setBody("Synthèse");
-  
+
         MimeMessage message = messageBuilder.buildMimeMessage();
         message.saveChanges();
 
         StringWriter sw = new StringWriter();
         ((MimeMultipart)message.getContent()).getBodyPart(0).writeTo(new WriterOutputStream(sw));
-        Assert.assertEquals("Content-Type: text/html; charset=ISO-8859-1\n"
+        assertEquals("Content-Type: text/html; charset=ISO-8859-1\n"
                 + "Content-Transfer-Encoding: quoted-printable\n\n"
-                + "Synth=E8se", 
+                + "Synth=E8se",
                 sw.toString().replaceAll("\r\n?", "\n"));
     }
 
     @Test
-    public void test_send() throws Exception {
+    void test_send() throws Exception {
         MimeMessageBuilder messageBuilder = new MimeMessageBuilder();
 
         messageBuilder
@@ -152,30 +150,30 @@ public class MimeMessageBuilderTest {
         Transport.send(mimeMessage);
 
         Mailbox mailbox = Mailbox.get("tom.xxxx@jenkins.com");
-        Assert.assertEquals(1, mailbox.getNewMessageCount());
+        assertEquals(1, mailbox.getNewMessageCount());
         Message message = mailbox.get(0);
-        Assert.assertEquals("Hello", message.getSubject());
-        Assert.assertEquals("Testing email", ((MimeMultipart)message.getContent()).getBodyPart(0).getContent().toString());
+        assertEquals("Hello", message.getSubject());
+        assertEquals("Testing email", ((MimeMultipart)message.getContent()).getBodyPart(0).getContent().toString());
     }
 
     @Test
     @Issue("JENKINS-26606")
-    public void test_addRecipients_tokenizer() throws Exception {
+    void test_addRecipients_tokenizer() throws Exception {
         MimeMessageBuilder messageBuilder = new MimeMessageBuilder();
 
         messageBuilder.addRecipients("tom.xxxx@gmail.com,tom.yyyy@gmail.com tom.zzzz@gmail.com");
         MimeMessage mimeMessage = messageBuilder.buildMimeMessage();
 
         Address[] recipients = mimeMessage.getAllRecipients();
-        Assert.assertEquals(3, recipients.length);
-        Assert.assertEquals("tom.xxxx@gmail.com", recipients[0].toString());
-        Assert.assertEquals("tom.yyyy@gmail.com", recipients[1].toString());
-        Assert.assertEquals("tom.zzzz@gmail.com", recipients[2].toString());
+        assertEquals(3, recipients.length);
+        assertEquals("tom.xxxx@gmail.com", recipients[0].toString());
+        assertEquals("tom.yyyy@gmail.com", recipients[1].toString());
+        assertEquals("tom.zzzz@gmail.com", recipients[2].toString());
     }
 
     @Test
     @Issue("JENKINS-32301")
-    public void testMultipleReplyToAddress() throws Exception {
+    void testMultipleReplyToAddress() throws Exception {
         checkMultipleReplyToAddress("%s %s %s");
         checkMultipleReplyToAddress("%s  , %s %s");
         checkMultipleReplyToAddress("%s %s, %s");
@@ -190,10 +188,10 @@ public class MimeMessageBuilderTest {
     private void checkMultipleReplyToAddress(MimeMessageBuilder messageBuilder) throws Exception {
         MimeMessage mimeMessage = messageBuilder.buildMimeMessage();
         Address[] recipients = mimeMessage.getReplyTo();
-        Assert.assertEquals(3, recipients.length);
-        Assert.assertEquals(X, recipients[0].toString());
-        Assert.assertEquals(Y, recipients[1].toString());
-        Assert.assertEquals(Z, recipients[2].toString());
+        assertEquals(3, recipients.length);
+        assertEquals(X, recipients[0].toString());
+        assertEquals(Y, recipients[1].toString());
+        assertEquals(Z, recipients[2].toString());
     }
 
 }


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations
* Migrate assertions
* Cleanup assertions
* Minor cleanup
* Remove public visibility of test classes and methods

There is once exception in `jenkins.plugins.mailer.FipsModeTest` which was not migrated as it uses `RealJenkinsRule` for which there is no JUnit4 equivalent yet.

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewd.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

