### PR TITLE
Migrate from Commons Lang to native Java Platform functionality

### DIFF
--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -45,7 +45,6 @@ import hudson.util.Secret;
 import hudson.util.XStream2;
 
 import jenkins.model.JenkinsLocationConfiguration;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -717,7 +716,7 @@ public class Mailer extends Notifier implements SimpleBuildStep {
                 msg.setSubject(Messages.Mailer_TestMail_Subject(testEmailCount.incrementAndGet()), charset);
                 msg.setText(Messages.Mailer_TestMail_Content(testEmailCount.get(), Jenkins.get().getDisplayName()), charset);
                 msg.setFrom(stringToAddress(adminAddress, charset));
-                if (StringUtils.isNotBlank(replyToAddress)) {
+                if (replyToAddress != null && !replyToAddress.isBlank()) {
                     msg.setReplyTo(new Address[]{stringToAddress(replyToAddress, charset)});
                 }
                 msg.setSentDate(new Date());

--- a/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
+++ b/src/main/java/jenkins/plugins/mailer/tasks/MimeMessageBuilder.java
@@ -29,7 +29,6 @@ import hudson.tasks.Mailer;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -201,7 +200,7 @@ public class MimeMessageBuilder {
         setJenkinsInstanceIdent(msg);
 
         msg.setContent("", contentType());
-        if (StringUtils.isNotBlank(from)) {
+        if (from != null && !from.isBlank()) {
             msg.setFrom(toNormalizedAddress(from));
         }
         msg.setSentDate(new Date());
@@ -286,7 +285,7 @@ public class MimeMessageBuilder {
 
     private List<InternetAddress> toNormalizedAddresses(String addresses) throws UnsupportedEncodingException {
         final List<InternetAddress> list = new LinkedList<>();
-        if (StringUtils.isNotBlank(addresses)) {
+        if (addresses != null && !addresses.isBlank()) {
             StringTokenizer tokens = new StringTokenizer(addresses, " \t\n\r\f,");
             while (tokens.hasMoreTokens()) {
                 String addressToken = tokens.nextToken();


### PR DESCRIPTION
No need to use a third-party library when this functionality is available in the Java Platform.