### PR TITLE
JENKINS-73430: Allow email recipients to be set from an env variable

### DIFF
--- a/src/main/resources/hudson/tasks/Mailer/config.jelly
+++ b/src/main/resources/hudson/tasks/Mailer/config.jelly
@@ -27,6 +27,12 @@ THE SOFTWARE.
   <f:entry field="recipients" title="${%Recipients}" description="${%description}">
     <f:textbox />
   </f:entry>
+  <f:entry field="useDynamicRecipients" title="">
+    <f:checkbox title="${%Use dynamic recipients from environment variable?}" />
+  </f:entry>
+  <f:entry field="dynamicRecipientsVar" title="${%Environment Variable Name}">
+    <f:textbox />
+  </f:entry>
   <f:entry field="notifyEveryUnstableBuild" title="">
     <f:checkbox title="${%Send e-mail for every unstable build}" default="true" />
   </f:entry>

--- a/src/test/java/hudson/tasks/MailerTest.java
+++ b/src/test/java/hudson/tasks/MailerTest.java
@@ -111,7 +111,7 @@ class MailerTest {
     }
 
     private TestProject create(JenkinsRule rule, boolean notifyEveryUnstableBuild, boolean sendToIndividuals) throws Exception {
-        Mailer m = new Mailer(RECIPIENT, notifyEveryUnstableBuild, sendToIndividuals);
+        Mailer m = new Mailer(RECIPIENT, notifyEveryUnstableBuild, sendToIndividuals, false, null);
         return new TestProject(rule, m);
     }
 
@@ -214,10 +214,10 @@ class MailerTest {
     @Email("http://www.nabble.com/email-recipients-disappear-from-freestyle-job-config-on-save-to25479293.html")
     @Test
     void testConfigRoundtrip(JenkinsRule rule) throws Exception {
-        Mailer m = new Mailer("kk@kohsuke.org", false, true);
+        Mailer m = new Mailer("kk@kohsuke.org", false, true, false, null);
         verifyRoundtrip(rule, m);
 
-        m = new Mailer("", true, false);
+        m = new Mailer("", true, false, false, null);
         verifyRoundtrip(rule, m);
     }
 
@@ -339,7 +339,7 @@ class MailerTest {
         // not configured.
         assertNull(new CleanJenkinsLocationConfiguration().getUrl());
 
-        Mailer m = new Mailer("", true, false);
+        Mailer m = new Mailer("", true, false, false, null);
         FreeStyleProject p = rule.createFreeStyleProject();
         p.getPublishersList().add(m);
         WebClient wc = rule.createWebClient();
@@ -639,7 +639,7 @@ class MailerTest {
         private final transient DumbSlave node;
 
         private MailerDisconnecting(JenkinsRule rule, DumbSlave node, String recipients, boolean notifyEveryUnstableBuild, boolean sendToIndividuals) {
-            super(recipients, notifyEveryUnstableBuild, sendToIndividuals);
+            super(recipients, notifyEveryUnstableBuild, sendToIndividuals, false, null);
             this.rule = rule;
             this.node = node;
         }


### PR DESCRIPTION
Fixes [JENKINS-73430](https://issues.jenkins.io/browse/JENKINS-73430)

This PR adds a feature to allow the e-mail recipient list to be read from an environment variable. This enables dynamic recipient lists based on build logic.

### Changes

  * Added a checkbox and text field to `config.jelly` for the new feature.
  * Updated `Mailer.java` to read from the specified environment variable when the feature is enabled.
  * Fixed compilation errors in `MailerTest.java` due to the updated constructor.

### Testing done

I manually verified this feature in multiple scenarios. The feature works correctly when the environment variable is formally injected into the Java build environment.

  * **Freestyle (Success):** Tested with a **Global Variable** ("Manage Jenkins") and with the **EnvInject plugin**. Both scenarios successfully sent an email to the correct dynamic recipients.
  * **Pipeline (Success):** Tested using the `envInject` step (`envInject(filePath: '...')`) to load the variable, which worked correctly.
  * **Automated Tests:** All existing unit tests pass via `mvn clean package`.

### Submitter checklist

  - [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch\!
  - [x] Ensure that the pull request title represents the desired changelog entry
  - [x] Please describe what you did
  - [x] Link to relevant issues in GitHub or Jira
  - [ ] Link to relevant pull requests, esp. upstream and downstream changes
  - [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed