### PR TITLE
JENKINS-68961: Fail gracefully on empty email address input

### DIFF
--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -213,6 +213,10 @@ public class Mailer extends Notifier implements SimpleBuildStep {
      */
     public static @NonNull InternetAddress stringToAddress(@NonNull String strAddress, 
             @NonNull String charset) throws AddressException, UnsupportedEncodingException {
+        if (strAddress.isBlank()) {
+            throw new AddressException(
+                    "Email address must not be empty. Please configure a valid email address.");
+        }
         Matcher m = ADDRESS_PATTERN.matcher(strAddress);
         if(!m.matches()) {
             return new InternetAddress(strAddress);

--- a/src/test/java/hudson/tasks/MailerTest.java
+++ b/src/test/java/hudson/tasks/MailerTest.java
@@ -40,6 +40,7 @@ import hudson.tasks.Mailer.DescriptorImpl;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import jakarta.mail.Address;
+import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
@@ -531,7 +532,14 @@ class MailerTest {
             Mailer.descriptor().doCheckSmtpHost("domain.com");
         }
     }
-
+    @Test
+    @Issue("JENKINS-68961")
+    public void emptyAddressShouldFailGracefully() {
+        AddressException ex = assertThrows(
+                AddressException.class,
+                () -> Mailer.stringToAddress("", "UTF-8"));
+        assertTrue(ex.getMessage().toLowerCase().contains("empty"));
+    }
     private static final class TestProject {
         private final JenkinsRule rule;
         private final FakeChangeLogSCM scm = new FakeChangeLogSCM();


### PR DESCRIPTION
### Description

Fixes JENKINS-68961 by failing gracefully when an empty or whitespace-only email
address is provided. Previously, blank values were passed to JavaMail, resulting
in an AddressException stack trace. This change adds explicit validation to
reject blank input early with a clear, user-friendly error message.

### Testing done

- Added a JUnit test (`emptyAddressShouldFailGracefully`) that verifies
  `Mailer.stringToAddress` fails gracefully when an empty email address is provided.
- Verified locally that the test fails without the fix and passes with the fix:
  `mvn -Dtest=MailerTest#emptyAddressShouldFailGracefully test`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira (JENKINS-68961)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes (not applicable)
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
